### PR TITLE
Refresh site content and layout

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,11 +1,22 @@
-<!DOCTYPE HTML>
-<!--
-	Prologue by HTML5 UP
-	html5up.net | @ajlkn
-	Free for personal and commercial use under the CCA 3.0 license (html5up.net/license)
--->
-<html>
-	<head>
-		<meta http-equiv="Refresh" content="0; url=index.html#contact">
-	</head>
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>Contact | Gleb Lukicov</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta
+            name="description"
+            content="Contact Gleb Lukicov, MLOps Leader."
+        />
+        <link rel="canonical" href="https://glukicov.github.io/#contact" />
+        <meta http-equiv="refresh" content="0; url=index.html#contact" />
+        <script>
+            location.replace("index.html#contact");
+        </script>
+    </head>
+    <body>
+        <p>
+            <a href="index.html#contact">Continue to contact</a>
+        </p>
+    </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,38 +1,59 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <!-- Global site tag (gtag.js) - Google Analytics -->
         <script
             async
             src="https://www.googletagmanager.com/gtag/js?id=G-JZQT6ZZKQV"
         ></script>
         <script>
             window.dataLayer = window.dataLayer || [];
-
             function gtag() {
                 dataLayer.push(arguments);
             }
-
             gtag("js", new Date());
             gtag("config", "G-JZQT6ZZKQV");
         </script>
-        <title>
-            Gleb Lukicov | MLOps Leader | Empowering Data Science Teams to
-            Succeed 🚀
-        </title>
+        <title>Gleb Lukicov | MLOps Leader | ML platforms &amp; cloud</title>
         <meta charset="utf-8" />
-        <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1, user-scalable=no"
-        />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta
             name="description"
-            content="Personal portfolio of Gleb Lukicov, MLOps Engineer and PhD in Physics"
+            content="Gleb Lukicov is an MLOps Leader working on ML platforms and cloud for data science and quant teams. PhD in Physics, and co-host of Europe's largest agentic AI community."
         />
         <meta
             name="google-site-verification"
             content="De6CTWP3ivSIWSPEWMinMMljAhdetnwRVDClJOsBiMg"
         />
+        <link rel="canonical" href="https://glukicov.github.io/" />
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://glukicov.github.io/" />
+        <meta
+            property="og:title"
+            content="Gleb Lukicov | MLOps Leader | ML platforms &amp; cloud"
+        />
+        <meta
+            property="og:description"
+            content="MLOps Leader · ML platforms &amp; cloud · data science and quant teams · PhD in Physics · co-host of Europe's largest agentic AI community."
+        />
+        <meta
+            property="og:image"
+            content="https://glukicov.github.io/images/main.png"
+        />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:site" content="@gleb_lukicov" />
+        <meta
+            name="twitter:title"
+            content="Gleb Lukicov | MLOps Leader | ML platforms &amp; cloud"
+        />
+        <meta
+            name="twitter:description"
+            content="MLOps Leader · ML platforms &amp; cloud · data science and quant teams · PhD in Physics · co-host of Europe's largest agentic AI community."
+        />
+        <meta
+            name="twitter:image"
+            content="https://glukicov.github.io/images/main.png"
+        />
+        <meta name="theme-color" content="#222629" />
         <link href="./images/icon.png" rel="icon" />
         <link
             href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css"
@@ -42,40 +63,32 @@
             href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap"
             rel="stylesheet"
         />
-
         <style>
             :root {
-                /* Color scheme */
                 --primary-color: #6d7221;
                 --primary-dark: #5a5f1c;
                 --primary-light: #8a9129;
                 --accent-color: #a2ad2e;
                 --text-light: #f5f5f5;
-                --text-dark: #333333;
+                --text-muted: #c5c7c8;
                 --bg-dark: #222629;
-                --bg-light: #f5f5f5;
+                --bg-alt: #1b1e20;
                 --card-bg: #2c2e30;
                 --card-hover: #3a3c3e;
-
-                /* Spacing */
+                --header-bg: rgba(34, 38, 41, 0.96);
+                --header-h: 64px;
                 --spacing-xs: 0.5rem;
                 --spacing-sm: 1rem;
                 --spacing-md: 2rem;
                 --spacing-lg: 3rem;
                 --spacing-xl: 5rem;
-
-                /* Border radius */
                 --border-radius-sm: 4px;
                 --border-radius-md: 8px;
                 --border-radius-lg: 16px;
-
-                /* Transitions */
                 --transition-fast: 0.2s ease;
                 --transition-normal: 0.3s ease;
-                --transition-slow: 0.5s ease;
             }
 
-            /* Reset and base styles */
             * {
                 margin: 0;
                 padding: 0;
@@ -95,48 +108,37 @@
                 overflow-x: hidden;
             }
 
-            h1,
-            h2,
-            h3,
-            h4,
-            h5,
-            h6 {
+            h1, h2, h3, h4, h5, h6 {
                 font-weight: 700;
                 line-height: 1.2;
                 margin-bottom: var(--spacing-sm);
                 color: var(--text-light);
             }
 
-            h1 {
-                font-size: 2.5rem;
-            }
+            h1 { font-size: 2.5rem; }
+            h2 { font-size: 2rem; }
+            h3 { font-size: 1.35rem; }
 
-            h2 {
-                font-size: 2rem;
-            }
-
-            h3 {
-                font-size: 1.75rem;
-            }
-
-            h4 {
-                font-size: 1.5rem;
-            }
-
-            p {
-                margin-bottom: var(--spacing-sm);
-            }
+            p { margin-bottom: var(--spacing-sm); }
 
             a {
-                color: var(--primary-light);
+                color: var(--accent-color);
                 text-decoration: none;
                 transition: color var(--transition-fast);
             }
 
             a:hover,
-            a:active,
-            a:focus {
-                color: #ab5249;
+            a:active {
+                color: var(--primary-light);
+            }
+
+            :focus {
+                outline: none;
+            }
+
+            :focus-visible {
+                outline: 2px solid var(--accent-color);
+                outline-offset: 3px;
             }
 
             img {
@@ -144,13 +146,28 @@
                 height: auto;
             }
 
-            ul,
-            ol {
+            ul, ol {
                 margin-left: var(--spacing-md);
                 margin-bottom: var(--spacing-sm);
             }
 
-            /* Container */
+            .skip-link {
+                position: absolute;
+                left: 0.75rem;
+                top: -100px;
+                z-index: 2000;
+                background: var(--accent-color);
+                color: var(--bg-dark);
+                padding: 0.6rem 1rem;
+                border-radius: var(--border-radius-sm);
+                font-weight: 700;
+            }
+
+            .skip-link:focus {
+                top: 0.75rem;
+                color: var(--bg-dark);
+            }
+
             .container {
                 width: 100%;
                 max-width: 1200px;
@@ -158,54 +175,57 @@
                 padding: 0 var(--spacing-sm);
             }
 
-            /* Header */
             .header {
-                background-color: var(--primary-color);
+                background-color: var(--header-bg);
+                backdrop-filter: blur(14px);
+                -webkit-backdrop-filter: blur(14px);
                 color: var(--text-light);
-                padding: var(--spacing-sm) 0;
                 position: fixed;
                 width: 100%;
+                height: var(--header-h);
                 top: 0;
                 z-index: 1000;
-                box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-                transition: all var(--transition-normal);
-            }
-
-            .header.scrolled {
-                padding: var(--spacing-xs) 0;
-                background-color: rgba(109, 114, 33, 0.95);
+                box-shadow: 0 2px 12px rgba(0, 0, 0, 0.35);
+                border-bottom: 1px solid rgba(162, 173, 46, 0.22);
             }
 
             .header-container {
                 display: flex;
                 justify-content: space-between;
                 align-items: center;
+                height: var(--header-h);
             }
 
             .logo {
                 display: flex;
                 align-items: center;
+                min-width: 0;
+                color: var(--text-light);
             }
+
+            .logo:hover { color: var(--text-light); }
 
             .logo img {
                 height: 40px;
-                width: auto;
+                width: 40px;
+                object-fit: cover;
                 margin-right: var(--spacing-xs);
                 border-radius: 50%;
             }
 
             .logo-text {
-                font-size: 1.5rem;
+                font-size: 1.15rem;
                 font-weight: 700;
                 color: var(--text-light);
+                white-space: nowrap;
             }
 
             .logo-subtitle {
-                font-size: 0.9rem;
-                opacity: 0.9;
+                font-size: 0.8rem;
+                opacity: 0.85;
+                white-space: nowrap;
             }
 
-            /* Navigation */
             .nav {
                 display: flex;
                 align-items: center;
@@ -215,36 +235,38 @@
                 display: flex;
                 list-style: none;
                 margin: 0;
+                flex-wrap: nowrap;
+                white-space: nowrap;
             }
 
-            .nav-item {
-                margin-left: var(--spacing-sm);
-            }
+            .nav-item { margin-left: 0.15rem; }
 
             .nav-link {
                 color: var(--text-light);
                 font-weight: 500;
-                padding: var(--spacing-xs) var(--spacing-sm);
+                font-size: 0.92rem;
+                padding: 0.4rem 0.55rem;
                 border-radius: var(--border-radius-sm);
-                transition: all var(--transition-fast);
+                transition: background-color var(--transition-fast), color var(--transition-fast);
+                white-space: nowrap;
             }
 
             .nav-link:hover {
-                background-color: var(--primary-dark);
+                background-color: rgba(162, 173, 46, 0.18);
+                color: var(--text-light);
             }
 
             .nav-link.active {
-                background-color: #ab5249;
+                background-color: var(--primary-color);
                 color: var(--text-light);
             }
 
             .nav-link i {
-                margin-right: var(--spacing-xs);
+                display: none;
+                margin-right: 0.4rem;
             }
 
-            .close-menu {
-                display: none; /* Hide close button by default for all screen sizes */
-            }
+            .close-menu { display: none; }
 
             .mobile-menu-btn {
                 display: none;
@@ -253,45 +275,66 @@
                 color: var(--text-light);
                 font-size: 1.5rem;
                 cursor: pointer;
+                padding: 0.35rem 0.5rem;
+                border-radius: var(--border-radius-sm);
             }
 
-            @media (max-width: 768px) {
-                .mobile-menu-btn {
-                    display: block;
-                }
+            .nav-backdrop {
+                display: none;
+                position: fixed;
+                inset: 0;
+                background: rgba(0, 0, 0, 0.5);
+                z-index: 1000;
+            }
+
+            .nav-backdrop.active { display: block; }
+
+            @media (max-width: 1040px) {
+                .mobile-menu-btn { display: block; }
 
                 .nav {
                     position: fixed;
                     top: 0;
                     right: -100%;
-                    width: 70%;
+                    width: min(22rem, 86%);
                     height: 100vh;
-                    background-color: var(--primary-color);
+                    height: 100dvh;
+                    background-color: #1f2224;
                     flex-direction: column;
                     align-items: flex-start;
-                    padding: var(--spacing-xl) var(--spacing-md);
+                    padding: 4.5rem var(--spacing-md) var(--spacing-md);
                     transition: right var(--transition-normal);
                     z-index: 1001;
+                    overflow-y: auto;
+                    border-left: 1px solid rgba(162, 173, 46, 0.25);
                 }
 
-                .nav.active {
-                    right: 0;
-                }
+                .nav.active { right: 0; }
 
                 .nav-list {
                     flex-direction: column;
                     width: 100%;
+                    white-space: normal;
                 }
 
                 .nav-item {
-                    margin: var(--spacing-xs) 0;
+                    margin: 0.15rem 0;
                     width: 100%;
                 }
 
                 .nav-link {
-                    display: block;
-                    padding: var(--spacing-sm);
+                    display: flex;
+                    align-items: center;
+                    padding: 0.85rem 0.75rem;
                     width: 100%;
+                    font-size: 1.05rem;
+                }
+
+                .nav-link i {
+                    display: inline-block;
+                    width: 1.4rem;
+                    text-align: center;
+                    color: var(--accent-color);
                 }
 
                 .close-menu {
@@ -303,46 +346,41 @@
                     color: var(--text-light);
                     font-size: 1.5rem;
                     cursor: pointer;
-                    display: none; /* Hide by default */
+                    display: none;
+                    padding: 0.4rem 0.55rem;
+                    border-radius: var(--border-radius-sm);
                 }
 
-                .nav.active .close-menu {
-                    display: block; /* Only show when nav is active */
-                }
+                .nav.active .close-menu { display: block; }
             }
 
-            /* Hero section */
             .hero {
                 background-color: var(--bg-dark);
                 background-image: url("./images/bg.gif");
                 background-size: cover;
                 background-position: center;
                 color: var(--text-light);
-                padding: calc(var(--spacing-xl) * 2) 0 var(--spacing-xl);
-                margin-top: 60px;
+                padding: calc(var(--spacing-xl) + var(--header-h)) 0 var(--spacing-xl);
+                margin-top: 0;
                 position: relative;
                 overflow: hidden;
             }
 
-            /* Main background gradient */
             .hero::before {
                 content: "";
                 position: absolute;
-                top: 0;
-                left: 0;
-                width: 100%;
-                height: 100%;
+                inset: 0;
                 background: linear-gradient(
                     135deg,
                     rgba(109, 114, 33, 0.6),
-                    rgba(34, 38, 41, 0.7)
+                    rgba(34, 38, 41, 0.78)
                 );
                 z-index: 1;
             }
 
             .hero-content {
                 position: relative;
-                z-index: 3; /* Ensure content is above both ::before and ::after */
+                z-index: 3;
                 display: flex;
                 flex-direction: column;
                 align-items: center;
@@ -359,21 +397,26 @@
             }
 
             .hero-title {
-                font-size: 2.5rem;
-                color: var(--text-light);
+                font-size: 2.6rem;
                 margin-bottom: var(--spacing-xs);
             }
 
             .hero-subtitle {
-                font-size: 1.5rem;
+                font-size: 1.15rem;
                 color: var(--text-light);
-                opacity: 0.9;
+                opacity: 0.95;
                 margin-bottom: var(--spacing-md);
+                max-width: 46rem;
+                font-weight: 400;
             }
 
             .hero-text {
-                max-width: 700px;
+                max-width: 42rem;
                 margin-bottom: var(--spacing-md);
+            }
+
+            .contact-prompt {
+                margin-bottom: 0;
             }
 
             .social-links {
@@ -395,87 +438,52 @@
             }
 
             .social-link:hover {
-                background-color: #ab5249;
+                background-color: var(--accent-color);
                 transform: translateY(-3px);
-                color: var(--text-light);
+                color: var(--bg-dark);
             }
 
-            .social-link i {
-                font-size: 1.2rem;
-            }
+            .social-link i { font-size: 1.2rem; }
 
-            /* Hero section social links */
-            .hero-social-links {
-                margin-top: var(--spacing-lg);
-            }
+            .hero-social-links { margin-top: var(--spacing-sm); }
 
             .hero-social-link {
                 width: 50px;
                 height: 50px;
                 background-color: var(--accent-color);
+                color: var(--bg-dark);
                 box-shadow: 0 0 10px rgba(162, 173, 46, 0.5);
-                transition: all 0.3s ease;
-                animation: pulse 2s infinite;
             }
 
-            .hero-social-link i {
-                font-size: 1.5rem;
-            }
+            .hero-social-link i { font-size: 1.5rem; }
 
             .hero-social-link:hover {
-                transform: translateY(-5px) scale(1.1);
-                background-color: #ab5249;
-                box-shadow: 0 0 15px rgba(171, 82, 73, 0.8);
+                transform: translateY(-5px) scale(1.08);
+                background-color: var(--primary-color);
                 color: var(--text-light);
+                box-shadow: 0 0 15px rgba(162, 173, 46, 0.7);
             }
 
-            @keyframes pulse {
-                0% {
-                    box-shadow: 0 0 0 0 rgba(162, 173, 46, 0.7);
-                }
-                70% {
-                    box-shadow: 0 0 0 10px rgba(162, 173, 46, 0);
-                }
-                100% {
-                    box-shadow: 0 0 0 0 rgba(162, 173, 46, 0);
-                }
+            section[id],
+            #contact {
+                scroll-margin-top: calc(var(--header-h) + 12px);
             }
 
-            /* Section styles */
             .section {
                 padding: var(--spacing-xl) 0;
                 position: relative;
-                overflow: hidden;
+                background-color: var(--bg-dark);
             }
 
-            /* Main background gradient */
-            .section::before {
-                content: "";
-                position: absolute;
-                top: 0;
-                left: 0;
-                width: 100%;
-                height: 100%;
-                background: linear-gradient(
-                    135deg,
-                    rgba(109, 114, 33, 0.8),
-                    rgba(34, 38, 41, 0.9)
-                );
-                z-index: 1;
-                pointer-events: none;
-            }
+            .section.alt { background-color: var(--bg-alt); }
 
-            .section-content {
-                position: relative;
-                z-index: 3;
-            }
+            .section-content { position: relative; z-index: 3; }
 
             .section-title {
                 text-align: center;
                 margin-bottom: var(--spacing-lg);
                 position: relative;
                 padding-bottom: var(--spacing-sm);
-                color: var(--text-light);
             }
 
             .section-title::after {
@@ -490,22 +498,22 @@
                 border-radius: var(--border-radius-sm);
             }
 
-            /* Card styles */
+            .section-lead {
+                max-width: 46rem;
+                margin: 0 auto var(--spacing-md);
+                text-align: center;
+                color: var(--text-muted);
+            }
+
             .card {
                 background-color: var(--card-bg);
                 border-radius: var(--border-radius-md);
                 overflow: hidden;
                 box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
-                transition:
-                    transform var(--transition-normal),
-                    box-shadow var(--transition-normal);
+                transition: transform var(--transition-normal), box-shadow var(--transition-normal);
                 height: 100%;
-                margin-bottom: var(--spacing-sm);
-            }
-
-            .card > img {
-                display: block;
-                width: 100%;
+                display: flex;
+                flex-direction: column;
             }
 
             .card:hover {
@@ -515,22 +523,27 @@
 
             .card-content {
                 padding: var(--spacing-sm);
-            }
-
-            .card > iframe {
-                display: block;
-                width: 100%;
+                display: flex;
+                flex-direction: column;
+                flex: 1;
             }
 
             .card-title {
-                font-size: 1.25rem;
+                font-size: 1.2rem;
                 margin-bottom: var(--spacing-xs);
-                color: var(--text-light);
             }
 
             .card-text {
                 margin-bottom: var(--spacing-xs);
                 color: var(--text-light);
+            }
+
+            .card-actions {
+                margin-top: auto;
+                display: flex;
+                flex-wrap: wrap;
+                gap: var(--spacing-xs);
+                padding-top: var(--spacing-xs);
             }
 
             .card-link {
@@ -539,84 +552,233 @@
                 background-color: var(--primary-color);
                 color: var(--text-light);
                 border-radius: var(--border-radius-sm);
-                transition: all var(--transition-fast);
+                transition: background-color var(--transition-fast), color var(--transition-fast);
                 text-decoration: none;
-                margin-top: var(--spacing-xs);
             }
 
             .card-link:hover {
-                background-color: #ab5249;
-                color: var(--text-light);
+                background-color: var(--accent-color);
+                color: var(--bg-dark);
             }
 
-            /* Grid layout */
             .grid {
                 display: grid;
-                grid-template-columns: repeat(1, 1fr);
+                grid-template-columns: 1fr;
                 gap: var(--spacing-md);
+                align-items: stretch;
             }
 
             @media (min-width: 768px) {
-                .grid-2 {
-                    grid-template-columns: repeat(2, 1fr);
-                }
+                .grid-2 { grid-template-columns: repeat(2, 1fr); }
             }
 
-            /* Project styles */
-            .project {
-                margin-bottom: var(--spacing-lg);
-            }
-
-            .project-header {
-                display: flex;
-                align-items: center;
-                margin-bottom: var(--spacing-sm);
-            }
-
-            .project-icon {
-                font-size: 1.5rem;
-                margin-right: var(--spacing-xs);
-                color: var(--primary-color);
-            }
-
-            .project-title {
-                margin-bottom: 0;
-            }
-
-            .project-img {
-                box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
-            }
-
-            /* Iframe container for responsive embeds */
-            .iframe-container {
+            .media-16x9 {
                 position: relative;
                 width: 100%;
-                padding-bottom: 56.25%; /* 16:9 Aspect Ratio */
-                height: 0;
+                aspect-ratio: 16 / 9;
                 overflow: hidden;
-                margin-bottom: 0;
+                background: #111;
             }
 
-            .iframe-container iframe {
+            .media-16x9 img {
+                width: 100%;
+                height: 100%;
+                object-fit: cover;
+                display: block;
+            }
+
+            .media-16x9 iframe {
                 position: absolute;
-                top: 0;
-                left: 0;
+                inset: 0;
                 width: 100%;
                 height: 100%;
                 border: 0;
             }
 
-            .video-embed {
-                background-color: #000000;
-                background-position: center;
-                background-size: cover;
+            .video-poster {
+                display: grid;
+                place-items: center;
+                cursor: pointer;
+                border: 0;
+                padding: 0;
+                width: 100%;
+                color: inherit;
+                font: inherit;
             }
 
-            .breakthrough-video {
-                background-image: url("https://i.ytimg.com/vi/GyWJ_dLydPE/hqdefault.jpg");
+            .video-poster img { grid-area: 1 / 1; }
+
+            .play-btn {
+                grid-area: 1 / 1;
+                width: 68px;
+                height: 68px;
+                border-radius: 50%;
+                border: 0;
+                background: rgba(109, 114, 33, 0.92);
+                color: var(--text-light);
+                font-size: 1.4rem;
+                z-index: 1;
+                display: grid;
+                place-items: center;
+                pointer-events: none;
+                box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
             }
 
-            /* Footer */
+            .video-poster:hover .play-btn,
+            .video-poster:focus-visible .play-btn {
+                background: var(--accent-color);
+                color: var(--bg-dark);
+            }
+
+            .static-media {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                gap: 0.6rem;
+                text-align: center;
+                padding: 1.25rem;
+                background:
+                    linear-gradient(135deg, rgba(109, 114, 33, 0.45), rgba(34, 38, 41, 0.9)),
+                    #1a1c14;
+                color: var(--text-light);
+            }
+
+            .static-media i { font-size: 2rem; color: var(--accent-color); }
+            .static-media span { font-weight: 500; max-width: 22rem; }
+
+            .timeline {
+                position: relative;
+                max-width: 48rem;
+                margin: 0 auto;
+                padding-left: 1.5rem;
+                border-left: 2px solid var(--primary-color);
+            }
+
+            .timeline-item {
+                position: relative;
+                margin-bottom: var(--spacing-md);
+                padding-left: 0.25rem;
+            }
+
+            .timeline-item:last-child { margin-bottom: 0; }
+
+            .timeline-item::before {
+                content: "";
+                position: absolute;
+                left: calc(-1.5rem - 5px);
+                top: 0.45rem;
+                width: 12px;
+                height: 12px;
+                border-radius: 50%;
+                background: var(--accent-color);
+                box-shadow: 0 0 0 3px rgba(162, 173, 46, 0.25);
+            }
+
+            .timeline-role {
+                font-size: 1.15rem;
+                margin-bottom: 0.2rem;
+            }
+
+            .timeline-meta {
+                color: var(--accent-color);
+                font-size: 0.95rem;
+                margin-bottom: 0.35rem;
+            }
+
+            .timeline-item p { margin-bottom: 0.35rem; }
+
+            .timeline-item ul {
+                margin-bottom: 0.4rem;
+                margin-left: 1.2rem;
+            }
+
+            .earlier-roles {
+                max-width: 48rem;
+                margin: var(--spacing-md) auto 0;
+                color: var(--text-muted);
+                font-size: 0.95rem;
+            }
+
+            .edu-grid {
+                display: grid;
+                gap: var(--spacing-md);
+                margin-top: var(--spacing-lg);
+            }
+
+            @media (min-width: 768px) {
+                .edu-grid { grid-template-columns: 1.2fr 0.8fr; }
+            }
+
+            .edu-list, .cert-list {
+                list-style: none;
+                margin-left: 0;
+            }
+
+            .edu-list li, .cert-list li {
+                margin-bottom: 0.7rem;
+                padding-left: 1.6rem;
+                position: relative;
+            }
+
+            .edu-list li::before,
+            .cert-list li::before {
+                position: absolute;
+                left: 0;
+                color: var(--accent-color);
+            }
+
+            .edu-list li::before { content: "🎓"; }
+            .cert-list li::before { content: "✓"; font-weight: 700; }
+
+            .resources {
+                display: grid;
+                gap: var(--spacing-md);
+            }
+
+            @media (min-width: 768px) {
+                .resources { grid-template-columns: 1fr 1fr; }
+            }
+
+            .resource-col {
+                max-width: 65ch;
+            }
+
+            .resource-col h3 { margin-bottom: var(--spacing-sm); }
+
+            .resource-col ul {
+                list-style: none;
+                margin-left: 0;
+            }
+
+            .resource-col li {
+                margin-bottom: 0.75rem;
+                padding-left: 1.7rem;
+                position: relative;
+            }
+
+
+            .plain-list {
+                list-style: none;
+                margin-left: 0;
+            }
+
+            .plain-list li {
+                margin-bottom: 0.65rem;
+                padding-left: 1.5rem;
+                position: relative;
+            }
+
+            .plain-list li::before {
+                content: "📝";
+                position: absolute;
+                left: 0;
+            }
+            .resource-col li .mark {
+                position: absolute;
+                left: 0;
+            }
+
             .footer {
                 background-color: var(--bg-dark);
                 background-image: url("./images/bg.gif");
@@ -631,10 +793,7 @@
             .footer::before {
                 content: "";
                 position: absolute;
-                top: 0;
-                left: 0;
-                width: 100%;
-                height: 100%;
+                inset: 0;
                 background: linear-gradient(
                     135deg,
                     rgba(109, 114, 33, 0.6),
@@ -644,153 +803,132 @@
                 pointer-events: none;
             }
 
-            .footer-content {
-                position: relative;
-                z-index: 2;
-            }
+            .footer-content { position: relative; z-index: 2; }
 
             .footer-social-links {
                 justify-content: center;
                 margin-bottom: var(--spacing-md);
             }
 
-            .footer-text {
-                margin-bottom: var(--spacing-sm);
+            .back-to-top {
+                position: fixed;
+                right: 1.1rem;
+                bottom: 1.1rem;
+                width: 44px;
+                height: 44px;
+                border-radius: 50%;
+                background: var(--primary-color);
+                color: var(--text-light);
+                display: grid;
+                place-items: center;
+                z-index: 900;
+                opacity: 0;
+                pointer-events: none;
+                transition: opacity var(--transition-fast), background-color var(--transition-fast);
+                box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
             }
 
-            .footer-link {
-                color: var(--primary-light);
+            .back-to-top.visible {
+                opacity: 1;
+                pointer-events: auto;
             }
 
-            .footer-link:hover {
-                color: #ab5249;
-                text-decoration: underline;
+            .back-to-top:hover {
+                background: var(--accent-color);
+                color: var(--bg-dark);
             }
 
-            /* Utility classes */
-            .text-center {
-                text-align: center;
-            }
+            .mb-0 { margin-bottom: 0; }
+            .mb-3 { margin-bottom: var(--spacing-md); }
+            .mt-3 { margin-top: var(--spacing-md); }
 
-            .mb-0 {
-                margin-bottom: 0;
-            }
-
-            .mb-1 {
-                margin-bottom: var(--spacing-xs);
-            }
-
-            .mb-2 {
-                margin-bottom: var(--spacing-sm);
-            }
-
-            .mb-3 {
-                margin-bottom: var(--spacing-md);
-            }
-
-            .mb-4 {
-                margin-bottom: var(--spacing-lg);
-            }
-
-            .mt-1 {
-                margin-top: var(--spacing-xs);
-            }
-
-            .mt-2 {
-                margin-top: var(--spacing-sm);
-            }
-
-            .mt-3 {
-                margin-top: var(--spacing-md);
-            }
-
-            .mt-4 {
-                margin-top: var(--spacing-lg);
-            }
-
-            /* Animation */
-            @keyframes fadeIn {
-                from {
-                    opacity: 0;
-                    transform: translateY(20px);
-                }
-                to {
-                    opacity: 1;
-                    transform: translateY(0);
-                }
-            }
-
-            .fade-in {
-                animation: fadeIn 0.5s ease forwards;
-            }
-
-            /* Responsive adjustments */
             @media (max-width: 768px) {
-                .hero-title {
-                    font-size: 2rem;
-                }
+                .hero-title { font-size: 2rem; }
+                .hero-subtitle { font-size: 1.02rem; }
+                .section { padding: var(--spacing-lg) 0; }
+                .logo-subtitle { display: none; }
+            }
 
-                .hero-subtitle {
-                    font-size: 1.25rem;
+            @media (prefers-reduced-motion: reduce) {
+                html { scroll-behavior: auto; }
+                .card, .social-link, .nav, .back-to-top, .hero-social-link {
+                    transition: none;
                 }
-
-                .section {
-                    padding: var(--spacing-lg) 0;
+                .card:hover, .social-link:hover, .hero-social-link:hover {
+                    transform: none;
                 }
             }
         </style>
     </head>
     <body>
-        <!-- Header -->
+        <a class="skip-link" href="#main">Skip to main content</a>
+
         <header class="header" id="header">
             <div class="container header-container">
-                <div class="logo">
-                    <img src="./images/icon.png" alt="Gleb Lukicov" />
+                <a class="logo" href="#about">
+                    <img src="./images/icon.png" alt="" />
                     <div>
                         <div class="logo-text">Gleb Lukicov</div>
-                        <div class="logo-subtitle">
-                            MLOps Leader | PhD in Physics
-                        </div>
+                        <div class="logo-subtitle">MLOps Leader</div>
                     </div>
-                </div>
+                </a>
 
-                <button class="mobile-menu-btn" id="mobile-menu-btn">
-                    <i class="fas fa-bars"></i>
+                <button
+                    type="button"
+                    class="mobile-menu-btn"
+                    id="mobile-menu-btn"
+                    aria-label="Open menu"
+                    aria-controls="nav"
+                    aria-expanded="false"
+                >
+                    <i class="fas fa-bars" aria-hidden="true"></i>
                 </button>
 
-                <nav class="nav" id="nav">
-                    <button class="close-menu" id="close-menu">
-                        <i class="fas fa-times"></i>
+                <div class="nav-backdrop" id="nav-backdrop"></div>
+
+                <nav class="nav" id="nav" aria-label="Primary">
+                    <button
+                        type="button"
+                        class="close-menu"
+                        id="close-menu"
+                        aria-label="Close menu"
+                    >
+                        <i class="fas fa-times" aria-hidden="true"></i>
                     </button>
                     <ul class="nav-list">
                         <li class="nav-item">
                             <a href="#about" class="nav-link"
-                                ><i class="fas fa-user"></i> About me
-                            </a>
+                                ><i class="fas fa-user" aria-hidden="true"></i> About</a
+                            >
                         </li>
                         <li class="nav-item">
-                            <a href="#mlops-community" class="nav-link"
-                                ><i class="fas fa-users"></i> MLOps
-                            </a>
+                            <a href="#experience" class="nav-link"
+                                ><i class="fas fa-briefcase" aria-hidden="true"></i> Experience</a
+                            >
+                        </li>
+                        <li class="nav-item">
+                            <a href="#community" class="nav-link"
+                                ><i class="fas fa-users" aria-hidden="true"></i> Community</a
+                            >
                         </li>
                         <li class="nav-item">
                             <a href="#ml" class="nav-link"
-                                ><i class="fas fa-sitemap"></i> ML Projects
-                            </a>
+                                ><i class="fas fa-sitemap" aria-hidden="true"></i> ML Projects</a
+                            >
                         </li>
                         <li class="nav-item">
                             <a href="#research" class="nav-link"
-                                ><i class="fas fa-atom"></i> Research
-                            </a>
+                                ><i class="fas fa-atom" aria-hidden="true"></i> Research</a
+                            >
                         </li>
                         <li class="nav-item">
                             <a href="#outreach" class="nav-link"
-                                ><i class="fas fa-handshake"></i> Outreach
-                            </a>
+                                ><i class="fas fa-handshake" aria-hidden="true"></i> Outreach</a
+                            >
                         </li>
                         <li class="nav-item">
                             <a href="#interests" class="nav-link"
-                                ><i class="fas fa-bicycle"></i> Interests</a
+                                ><i class="fas fa-bicycle" aria-hidden="true"></i> Interests</a
                             >
                         </li>
                     </ul>
@@ -798,181 +936,352 @@
             </div>
         </header>
 
-        <!-- Hero Section -->
+        <main id="main">
         <section class="hero" id="about">
             <div class="container hero-content">
                 <img
                     src="./images/main.png"
-                    alt="Gleb Lukicov"
+                    alt="Portrait of Gleb Lukicov"
                     class="hero-img"
+                    width="150"
+                    height="150"
                 />
-                <!--            <h1 class="hero-title">Gleb Lukicov</h1>-->
-                <!--            <h2 class="hero-subtitle">MLOps Leader | Empowering Data Science Teams to Succeed 🚀</h2>-->
-                <p class="hero-text">
-                    Hey there, I'm Gleb, and I'm passionate about empowering
-                    data science teams to succeed by building reliable and
-                    scalable MLOps solutions — because effective MLOps isn't
-                    just about tools; it's about aligning people, processes, and
-                    platforms to solve real business problems.
-                    <br /><br />
-                    Outside of work, I co-organise the London MLOps community —
-                    Europe's largest MLOps meetup — and love sharing what I've
-                    learned through blogging and public speaking.
-                    <br /><br />
-                    Before entering the tech industry, I conducted scientific
-                    research at world-class physics labs in the US and
-                    Switzerland, working on large-scale, multidisciplinary
-                    projects. In my spare time, I enjoy road cycling and
-                    running.
+                <h1 class="hero-title">Gleb Lukicov</h1>
+                <p class="hero-subtitle">
+                    MLOps Leader · ML platforms &amp; cloud · data science and
+                    quant teams · PhD in Physics · co-host of Europe’s largest
+                    agentic AI community
                 </p>
-                Contact me for collaboration ideas or questions ⬇️
-                <div class="social-links hero-social-links">
-                    <a
-                        href="https://www.linkedin.com/in/glukicov"
-                        target="_blank"
-                        class="social-link hero-social-link"
-                        title="LinkedIn"
-                    >
-                        <i class="fab fa-linkedin-in"></i>
-                    </a>
-                    <a
-                        href="https://github.com/glukicov"
-                        target="_blank"
-                        class="social-link hero-social-link"
-                        title="GitHub"
-                    >
-                        <i class="fab fa-github"></i>
-                    </a>
-                    <a
-                        href="https://medium.com/@lukicov"
-                        target="_blank"
-                        class="social-link hero-social-link"
-                        title="Medium"
-                    >
-                        <i class="fab fa-medium-m"></i>
-                    </a>
-                    <a
-                        href="https://x.com/gleb_lukicov"
-                        target="_blank"
-                        class="social-link hero-social-link"
-                        title="X (Twitter)"
-                    >
-                        <i class="fab fa-x-twitter"></i>
-                    </a>
+                <div class="hero-text">
+                    <p>
+                        Hey there, I’m Gleb. I’m passionate about empowering
+                        data science teams to succeed by building reliable,
+                        scalable ML platforms — because effective MLOps isn’t
+                        just about tools; it’s about aligning people, processes,
+                        and platforms to solve real problems.
+                    </p>
+                    <p>
+                        Outside of work I co-host Europe’s largest agentic AI
+                        community with the
+                        <a
+                            href="https://aaif.io/"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            >Agentic AI Foundation</a
+                        >
+                        in London, and I enjoy sharing what I’ve learned through
+                        blogging and public speaking. From 2023 to 2026 I
+                        organised
+                        <a
+                            href="https://mlops.community"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            >MLOps Community London</a
+                        >
+                        — 20+ in-person events, including a flagship with 500
+                        guests and 30 presenters.
+                    </p>
+                    <p class="mb-0">
+                        Before entering the tech industry, I conducted
+                        scientific research at world-class physics labs in the
+                        US and Switzerland, working on large-scale,
+                        multidisciplinary projects. In my spare time I enjoy
+                        road cycling and running.
+                    </p>
+                </div>
+                <div id="contact">
+                    <p class="contact-prompt">
+                        Contact me for collaboration ideas or questions
+                    </p>
+                    <div class="social-links hero-social-links">
+                        <a
+                            href="https://www.linkedin.com/in/glukicov"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="social-link hero-social-link"
+                            aria-label="Gleb Lukicov on LinkedIn"
+                        >
+                            <i class="fab fa-linkedin-in" aria-hidden="true"></i>
+                        </a>
+                        <a
+                            href="https://github.com/glukicov"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="social-link hero-social-link"
+                            aria-label="Gleb Lukicov on GitHub"
+                        >
+                            <i class="fab fa-github" aria-hidden="true"></i>
+                        </a>
+                        <a
+                            href="https://medium.com/@lukicov"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="social-link hero-social-link"
+                            aria-label="Gleb Lukicov on Medium"
+                        >
+                            <i class="fab fa-medium-m" aria-hidden="true"></i>
+                        </a>
+                        <a
+                            href="https://x.com/gleb_lukicov"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="social-link hero-social-link"
+                            aria-label="Gleb Lukicov on X"
+                        >
+                            <i class="fab fa-x-twitter" aria-hidden="true"></i>
+                        </a>
+                    </div>
                 </div>
             </div>
         </section>
 
-        <!-- MLOps Community Section -->
-        <section class="section" id="mlops-community">
+        <section class="section alt" id="experience">
             <div class="container section-content">
-                <h2 class="section-title">MLOps Community London 🇬🇧</h2>
+                <h2 class="section-title">Experience</h2>
+                <div class="timeline">
+                    <article class="timeline-item">
+                        <h3 class="timeline-role">London Community Organiser</h3>
+                        <p class="timeline-meta">
+                            <a href="https://aaif.io/" target="_blank" rel="noopener noreferrer">Agentic AI Foundation</a>
+                            · Part-time · May 2026–Present
+                        </p>
+                        <p>
+                            Co-host of Europe’s largest agentic AI community.
+                        </p>
+                    </article>
 
-                <div class="grid grid-2 mb-3">
+                    <article class="timeline-item">
+                        <h3 class="timeline-role">London Community Organiser</h3>
+                        <p class="timeline-meta">
+                            <a href="https://mlops.community" target="_blank" rel="noopener noreferrer">MLOps Community</a>
+                            · Part-time · Apr 2023–May 2026
+                        </p>
+                        <p>
+                            Organised 20+ in-person events for practitioners,
+                            including a flagship meetup with 500 guests and 30
+                            presenters.
+                        </p>
+                    </article>
+
+                    <article class="timeline-item">
+                        <h3 class="timeline-role">Founding MLOps Engineer</h3>
+                        <p class="timeline-meta">
+                            <a href="https://www.electrictwin.com" target="_blank" rel="noopener noreferrer">Electric Twin</a>
+                            · Full-time · May 2024–Apr 2026
+                        </p>
+                        <p>
+                            B2B SaaS building LLM-powered synthetic populations.
+                            Led experimentation and data platforms so customers
+                            could explore decisions with digital personas.
+                        </p>
+                    </article>
+
+                    <article class="timeline-item">
+                        <h3 class="timeline-role">Virgin Media O2, London</h3>
+                        <p class="timeline-meta">Full-time · Jan 2021–Apr 2024</p>
+                        <ul>
+                            <li>MLOps Engineering Manager · Jul 2022–Apr 2024</li>
+                            <li>MLOps Engineer · Apr 2021–Jul 2022</li>
+                            <li>Data Scientist · Jan 2021–Apr 2021</li>
+                        </ul>
+                        <p>
+                            Grew a team of MLOps engineers enabling data
+                            scientists to deploy models serving tens of millions
+                            of customers. The team won Google Cloud DevOps
+                            awards in 2022 and 2023.
+                        </p>
+                    </article>
+
+                    <article class="timeline-item">
+                        <h3 class="timeline-role">Researcher</h3>
+                        <p class="timeline-meta">
+                            <a href="https://muon-g-2.fnal.gov/" target="_blank" rel="noopener noreferrer">Fermilab</a>
+                            · Sep 2016–Sep 2020 · PhD
+                        </p>
+                        <p>
+                            Muon <i>g − 2</i> experiment: tracking-detector
+                            alignment software and muon electric dipole moment
+                            studies, with 200 scientists and engineers.
+                        </p>
+                    </article>
+                </div>
+                <p class="earlier-roles">
+                    Earlier: data science with Just Eat / Faculty (2020); UCL
+                    teaching demonstrator; internship at PSI (2015).
+                </p>
+
+                <div class="edu-grid">
                     <div class="card">
-                        <img
-                            src="./images/gleb-mlops.png"
-                            alt="MLOps Community London"
-                            style="width: 100%"
-                        />
                         <div class="card-content">
+                            <h3 class="card-title">Education</h3>
+                            <ul class="edu-list">
+                                <li>
+                                    <strong>UCL</strong> — PhD Experimental
+                                    Particle Physics
+                                    (<a href="https://arxiv.org/abs/1909.12900" target="_blank" rel="noopener noreferrer">arXiv:1909.12900</a>;
+                                    <a href="files/PhDThesis_Gleb_Lukicov.pdf" target="_blank" rel="noopener noreferrer">thesis PDF</a>)
+                                </li>
+                                <li>
+                                    <strong>UCL</strong> — MSci Physics, 1st
+                                    class
+                                </li>
+                                <li>
+                                    <strong>Woodhouse College</strong> —
+                                    A-levels Maths, Further Maths, Physics,
+                                    Chemistry
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="card">
+                        <div class="card-content">
+                            <h3 class="card-title">Certifications</h3>
+                            <ul class="cert-list">
+                                <li>
+                                    <a href="https://www.cncf.io/training/certification/ckad/" target="_blank" rel="noopener noreferrer">CKAD</a>
+                                    — CNCF, March 2026
+                                </li>
+                                <li>
+                                    Anthropic MCP courses (Introduction and
+                                    Advanced Topics) — Jun–Jul 2025
+                                </li>
+                                <li>
+                                    <a href="https://huggingface.co/learn/mcp-course" target="_blank" rel="noopener noreferrer">Hugging Face MCP Course</a>
+                                    — Jun–Jul 2025
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="section" id="community">
+            <div class="container section-content">
+                <h2 class="section-title">Community</h2>
+                <div class="grid grid-2">
+                    <article class="card">
+                        <div class="media-16x9 static-media" aria-hidden="true">
+                            <i class="fas fa-robot"></i>
+                            <span>Agentic AI Foundation · London</span>
+                        </div>
+                        <div class="card-content">
+                            <h3 class="card-title">Agentic AI Foundation</h3>
+                            <p class="timeline-meta">London Community Organiser · May 2026–present</p>
                             <p class="card-text">
-                                I am actively engaged in the
-                                <a
-                                    href="https://mlops.community"
-                                    target="_blank"
-                                    >MLOps Community London</a
-                                >, the largest MLOps community in Europe, as a
-                                co-host and events organiser. We are putting
-                                regular in-person meetup-ups, for the community
-                                to learn together and discuss latest MLOps
-                                trends over 🍕.
+                                I co-host the London chapter of the
+                                <a href="https://aaif.io/" target="_blank" rel="noopener noreferrer">Agentic AI Foundation</a>
+                                — Europe’s largest agentic AI community. We run
+                                in-person meetups for people building with
+                                agents, MCP, and open standards.
                             </p>
-                            <a
-                                href="https://luma.com/aaif-london"
-                                target="_blank"
-                                class="card-link"
-                                >Check our upcoming events in London</a
-                            >
+                            <div class="card-actions">
+                                <a
+                                    href="https://luma.com/aaif-london"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="card-link"
+                                    >Upcoming London events</a
+                                >
+                            </div>
                         </div>
-                    </div>
+                    </article>
 
-                    <div class="card">
-                        <iframe
-                            src="https://www.linkedin.com/embed/feed/update/urn:li:ugcPost:7311105895734693888"
-                            height="650"
-                            width="100%"
-                            allowfullscreen=""
-                            frameborder="0"
-                            title="Embedded post"
-                        ></iframe>
-                        <div class="card-content">
-                            <a
-                                href="https://gatewaze.mlops.community/?mode=slack#email"
-                                target="_blank"
-                                class="card-link"
-                                >Join the MLOps Community</a
-                            >
+                    <article class="card">
+                        <div class="media-16x9">
+                            <img
+                                src="./images/gleb-mlops.png"
+                                alt="Gleb speaking at MLOps Community London"
+                                loading="lazy"
+                            />
                         </div>
-                    </div>
+                        <div class="card-content">
+                            <h3 class="card-title">MLOps Community London</h3>
+                            <p class="timeline-meta">London Community Organiser · Apr 2023–May 2026</p>
+                            <p class="card-text">
+                                I co-hosted regular in-person meetups for
+                                <a href="https://mlops.community" target="_blank" rel="noopener noreferrer">MLOps Community London</a>,
+                                then Europe’s largest MLOps meetup — 20+ events,
+                                including a flagship with 500 guests and 30
+                                presenters, for the community to learn together
+                                and discuss MLOps trends over pizza.
+                            </p>
+                            <div class="card-actions">
+                                <a
+                                    href="https://www.linkedin.com/feed/update/urn:li:ugcPost:7311105895734693888"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="card-link"
+                                    >Flagship event on LinkedIn</a
+                                >
+                                <a
+                                    href="https://gatewaze.mlops.community/?mode=slack#email"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="card-link"
+                                    >Join the MLOps Community</a
+                                >
+                            </div>
+                        </div>
+                    </article>
                 </div>
             </div>
         </section>
 
-        <!-- ML Projects Section -->
-        <section class="section" id="ml">
+        <section class="section alt" id="ml">
             <div class="container section-content">
-                <h2 class="section-title">ML projects and articles 📚</h2>
+                <h2 class="section-title">ML projects and articles</h2>
 
                 <div class="grid grid-2">
-                    <!-- Project 1 -->
-                    <div class="card">
+                    <article class="card">
                         <a
                             href="https://medium.com/@lukicov/to-mlops-or-not-to-mlops-that-is-the-question-the-platform-is-the-answer-e148a8286b90"
                             target="_blank"
+                            rel="noopener noreferrer"
+                            class="media-16x9"
                         >
                             <img
                                 src="./images/mlops-cover-full.png"
-                                alt="MLOps Article"
-                                style="width: 100%"
+                                alt="Cover image for To MLOps, or not to MLOps?"
+                                loading="lazy"
                             />
                         </a>
                         <div class="card-content">
-                            <h3 class="card-title">
-                                To MLOps, or not to MLOps? 🤔
-                            </h3>
+                            <h3 class="card-title">To MLOps, or not to MLOps?</h3>
                             <p class="card-text">
                                 That is the question —
-                                <i>the platform is the answer</i> 🚀. How does a
+                                <i>the platform is the answer</i>. How does a
                                 correct MLOps strategy enable success for data
                                 science projects in a large organisation? What
                                 is an effective MLOps team?
                             </p>
-                            <a
-                                href="https://medium.com/@lukicov/to-mlops-or-not-to-mlops-that-is-the-question-the-platform-is-the-answer-e148a8286b90"
-                                target="_blank"
-                                class="card-link"
-                                >Read on Medium</a
-                            >
+                            <div class="card-actions">
+                                <a
+                                    href="https://medium.com/@lukicov/to-mlops-or-not-to-mlops-that-is-the-question-the-platform-is-the-answer-e148a8286b90"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="card-link"
+                                    >Read on Medium</a
+                                >
+                            </div>
                         </div>
-                    </div>
+                    </article>
 
-                    <!-- Project 2 -->
-                    <div class="card">
+                    <article class="card">
                         <a
                             href="https://medium.com/@lukicov/ml-pipelines-in-the-age-of-llms-from-local-containers-to-cloud-experiments-1b688dcebee5"
                             target="_blank"
+                            rel="noopener noreferrer"
+                            class="media-16x9"
                         >
                             <img
                                 src="./images/steps.png"
-                                alt="ML Pipelines"
-                                style="width: 100%"
+                                alt="Diagram of ML pipeline steps"
+                                loading="lazy"
                             />
                         </a>
                         <div class="card-content">
-                            <h3 class="card-title">
-                                ML pipelines in the age of LLMs
-                            </h3>
+                            <h3 class="card-title">ML pipelines in the age of LLMs</h3>
                             <p class="card-text">
                                 Are you an AI engineer trying to bridge local
                                 development and production deployment of ML
@@ -980,379 +1289,313 @@
                                 experimentation with Docker and uv on Google
                                 Cloud.
                             </p>
-                            <a
-                                href="https://medium.com/@lukicov/ml-pipelines-in-the-age-of-llms-from-local-containers-to-cloud-experiments-1b688dcebee5"
-                                target="_blank"
-                                class="card-link"
-                                >Read on Medium</a
-                            >
-                            <a
-                                href="https://github.com/glukicov/llm_pipelines_demo"
-                                target="_blank"
-                                class="card-link"
-                                >Demo on GitHub</a
-                            >
+                            <div class="card-actions">
+                                <a
+                                    href="https://medium.com/@lukicov/ml-pipelines-in-the-age-of-llms-from-local-containers-to-cloud-experiments-1b688dcebee5"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="card-link"
+                                    >Read on Medium</a
+                                >
+                                <a
+                                    href="https://github.com/glukicov/llm_pipelines_demo"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="card-link"
+                                    >Demo on GitHub</a
+                                >
+                            </div>
                         </div>
-                    </div>
+                    </article>
                 </div>
 
                 <div class="grid grid-2 mt-3">
-                    <!-- Project 3 -->
-                    <div class="card">
-                        <div class="iframe-container">
-                            <iframe
-                                src="https://www.youtube.com/embed/bYUjAz_Q1Gs"
-                                allow="
-                                    accelerometer;
-                                    autoplay;
-                                    clipboard-write;
-                                    encrypted-media;
-                                    gyroscope;
-                                    picture-in-picture;
-                                "
-                                allowfullscreen
-                            ></iframe>
-                        </div>
+                    <article class="card">
+                        <button
+                            type="button"
+                            class="media-16x9 video-poster"
+                            data-youtube="bYUjAz_Q1Gs"
+                            data-title="Virgin Media O2: DevOps journey"
+                            aria-label="Play video: Virgin Media O2 DevOps journey"
+                        >
+                            <img
+                                src="https://i.ytimg.com/vi/bYUjAz_Q1Gs/hqdefault.jpg"
+                                alt="Video thumbnail: Virgin Media O2 DevOps journey"
+                                loading="lazy"
+                            />
+                            <span class="play-btn" aria-hidden="true"
+                                ><i class="fas fa-play"></i
+                            ></span>
+                        </button>
                         <div class="card-content">
-                            <h3 class="card-title">
-                                Virgin Media O2: DevOps journey
-                            </h3>
+                            <h3 class="card-title">Virgin Media O2: DevOps journey</h3>
                             <p class="card-text">
-                                In this video, I share my professional journey
-                                at Virgin Media O2, where we are utilising the
-                                power of Google Cloud to enable us to make
-                                data-driven decisions that improve our
-                                customers' experiences. For this work, our team
+                                In this video I share my professional journey at
+                                Virgin Media O2, where we utilised Google Cloud
+                                to make data-driven decisions that improved our
+                                customers’ experiences. For this work, our team
                                 won the DevOps award in 2022 and 2023.
                             </p>
-                            <a
-                                href="https://cloud.google.com/blog/products/devops-sre/devops-awards-2022-winner-vmo2"
-                                target="_blank"
-                                class="card-link"
-                                >More on our DevOps award</a
-                            >
+                            <div class="card-actions">
+                                <a
+                                    href="https://www.youtube.com/watch?v=bYUjAz_Q1Gs"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="card-link"
+                                    >Watch on YouTube</a
+                                >
+                                <a
+                                    href="https://cloud.google.com/blog/products/devops-sre/devops-awards-2022-winner-vmo2"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="card-link"
+                                    >DevOps award write-up</a
+                                >
+                            </div>
                         </div>
-                    </div>
+                    </article>
 
-                    <!-- Project 4 -->
-                    <div class="card">
-                        <div class="iframe-container">
-                            <iframe
-                                src="https://www.youtube.com/embed/6cMVcKeBdkI"
-                                allow="
-                                    accelerometer;
-                                    autoplay;
-                                    clipboard-write;
-                                    encrypted-media;
-                                    gyroscope;
-                                    picture-in-picture;
-                                "
-                                allowfullscreen
-                            ></iframe>
-                        </div>
+                    <article class="card">
+                        <button
+                            type="button"
+                            class="media-16x9 video-poster"
+                            data-youtube="6cMVcKeBdkI"
+                            data-title="Interview with the Royal Statistical Society"
+                            aria-label="Play video: Interview with the Royal Statistical Society"
+                        >
+                            <img
+                                src="https://i.ytimg.com/vi/6cMVcKeBdkI/hqdefault.jpg"
+                                alt="Video thumbnail: Royal Statistical Society interview"
+                                loading="lazy"
+                            />
+                            <span class="play-btn" aria-hidden="true"
+                                ><i class="fas fa-play"></i
+                            ></span>
+                        </button>
                         <div class="card-content">
-                            <h3 class="card-title">
-                                Interview with the Royal Statistical Society
-                            </h3>
+                            <h3 class="card-title">Interview with the Royal Statistical Society</h3>
                             <p class="card-text">
-                                In this interview, I share my journey from
-                                particle physics to data science and MLOps, and
-                                how I discovered a passion for building data
-                                platforms and helping teams work with data at
-                                scale. I talk about my path into the field, my
-                                proudest moments as an ML engineering manager,
-                                and the importance of good fundamentals,
-                                community, and clean data.
+                                I share my journey from particle physics to data
+                                science and MLOps, and how I discovered a
+                                passion for building data platforms and helping
+                                teams work with data at scale — plus the
+                                importance of good fundamentals, community, and
+                                clean data.
                             </p>
+                            <div class="card-actions">
+                                <a
+                                    href="https://www.youtube.com/watch?v=6cMVcKeBdkI"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="card-link"
+                                    >Watch on YouTube</a
+                                >
+                            </div>
                         </div>
-                    </div>
+                    </article>
                 </div>
 
                 <div class="grid grid-2 mt-3">
-                    <!-- Project 5 -->
-                    <div class="card">
-                        <iframe
-                            style="border-radius: 12px"
-                            src="https://open.spotify.com/embed/episode/0Xgw37MAKB1R7zGyBKehPe?utm_source=generator&t=0"
-                            width="100%"
-                            height="352"
-                            frameborder="0"
-                            allowfullscreen=""
-                            allow="
-                                autoplay;
-                                clipboard-write;
-                                encrypted-media;
-                                fullscreen;
-                                picture-in-picture;
-                            "
-                            loading="lazy"
-                        ></iframe>
+                    <article class="card">
+                        <a
+                            href="https://open.spotify.com/episode/0Xgw37MAKB1R7zGyBKehPe"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="media-16x9 static-media"
+                        >
+                            <i class="fab fa-spotify"></i>
+                            <span>Podcast episode on Spotify</span>
+                        </a>
                         <div class="card-content">
-                            <h3 class="card-title">
-                                Electric Twin & MLOps Community London
-                            </h3>
+                            <h3 class="card-title">Electric Twin &amp; MLOps Community London</h3>
                             <p class="card-text">
-                                In this podcast, I discuss why your business
-                                might benefit from MLOps, MLOps Community London
-                                meetups and the exciting work we do at Electric
-                                Twin on simulating human behaviour in real-time
-                                with AI.
+                                In this podcast I discussed why a business might
+                                benefit from MLOps, MLOps Community London
+                                meetups, and the work we did at Electric Twin on
+                                simulating human behaviour in real time with AI.
                             </p>
-                            <a
-                                href="https://www.electrictwin.com"
-                                target="_blank"
-                                class="card-link"
-                                >Learn more about our work on digital
-                                personas</a
-                            >
+                            <div class="card-actions">
+                                <a
+                                    href="https://open.spotify.com/episode/0Xgw37MAKB1R7zGyBKehPe"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="card-link"
+                                    >Listen on Spotify</a
+                                >
+                                <a
+                                    href="https://www.electrictwin.com"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="card-link"
+                                    >Electric Twin</a
+                                >
+                            </div>
                         </div>
-                    </div>
-                    <!-- Project 6 -->
-                    <div class="card">
+                    </article>
+
+                    <article class="card">
                         <a
                             href="https://medium.com/data-science/set-up-of-a-personal-gpu-server-for-machine-learning-with-ubuntu-20-04-100e787105ad"
                             target="_blank"
+                            rel="noopener noreferrer"
+                            class="media-16x9"
                         >
                             <img
                                 src="./images/gpu.jpeg"
-                                alt="GPU Server"
-                                style="width: 100%"
+                                alt="Personal GPU server hardware"
+                                loading="lazy"
                             />
                         </a>
                         <div class="card-content">
-                            <h3 class="card-title">
-                                Personal GPU server for ML
-                            </h3>
+                            <h3 class="card-title">Personal GPU server for ML</h3>
                             <p class="card-text">
                                 With Ubuntu, CUDA and port-forwarding. I cover
-                                how to set up secure remote access over ssh,
-                                wake-on-LAN feature to switch on your GPU server
-                                remotely and mounting the remote file system on
-                                your laptop.
+                                how to set up secure remote access over SSH,
+                                wake-on-LAN to switch on a GPU server remotely,
+                                and mounting the remote file system on a laptop.
                             </p>
-                            <a
-                                href="https://medium.com/data-science/set-up-of-a-personal-gpu-server-for-machine-learning-with-ubuntu-20-04-100e787105ad"
-                                target="_blank"
-                                class="card-link"
-                                >Read on TDS</a
-                            >
+                            <div class="card-actions">
+                                <a
+                                    href="https://medium.com/data-science/set-up-of-a-personal-gpu-server-for-machine-learning-with-ubuntu-20-04-100e787105ad"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="card-link"
+                                    >Read on TDS</a
+                                >
+                            </div>
                         </div>
-                    </div>
+                    </article>
                 </div>
 
                 <div class="grid grid-2 mt-3">
-                    <!-- Project 7 -->
-                    <div class="card">
+                    <article class="card">
                         <a
                             href="https://www.electrictwin.com/blog/electric-twin-is-iso-27001-certified"
                             target="_blank"
+                            rel="noopener noreferrer"
+                            class="media-16x9"
                         >
                             <img
                                 src="./images/iso.png"
-                                alt="Electric Twin ISO 27001 certification"
-                                style="width: 100%"
+                                alt="Electric Twin ISO 27001 certification graphic"
+                                loading="lazy"
                             />
                         </a>
                         <div class="card-content">
-                            <h3 class="card-title">
-                                Electric Twin is ISO 27001 certified
-                            </h3>
+                            <h3 class="card-title">Electric Twin ISO 27001 certification</h3>
                             <p class="card-text">
-                                Startups move fast, and as it turns out, you can
-                                move fast on security & compliance too!
+                                While I was at Electric Twin, the company became
+                                ISO 27001 certified. Startups move fast — and as
+                                it turns out, you can move fast on security and
+                                compliance too.
                             </p>
-                            <a
-                                href="https://www.electrictwin.com/blog/electric-twin-is-iso-27001-certified"
-                                target="_blank"
-                                class="card-link"
-                                >Read the announcement</a
-                            >
+                            <div class="card-actions">
+                                <a
+                                    href="https://www.electrictwin.com/blog/electric-twin-is-iso-27001-certified"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="card-link"
+                                    >Read the announcement</a
+                                >
+                            </div>
                         </div>
-                    </div>
+                    </article>
 
-                    <!-- Project 8 -->
-                    <div class="card">
-                        <div class="iframe-container">
-                            <iframe
-                                src="https://www.youtube.com/embed/Zv5CWN5Dp9A"
-                                allow="
-                                    accelerometer;
-                                    autoplay;
-                                    clipboard-write;
-                                    encrypted-media;
-                                    gyroscope;
-                                    picture-in-picture;
-                                "
-                                allowfullscreen
-                            ></iframe>
-                        </div>
+                    <article class="card">
+                        <button
+                            type="button"
+                            class="media-16x9 video-poster"
+                            data-youtube="Zv5CWN5Dp9A"
+                            data-title="Inspired to Build: Live with Gleb Lukicov"
+                            aria-label="Play video: Inspired to Build live with Gleb Lukicov"
+                        >
+                            <img
+                                src="https://i.ytimg.com/vi/Zv5CWN5Dp9A/hqdefault.jpg"
+                                alt="Video thumbnail: Inspired to Build live conversation"
+                                loading="lazy"
+                            />
+                            <span class="play-btn" aria-hidden="true"
+                                ><i class="fas fa-play"></i
+                            ></span>
+                        </button>
                         <div class="card-content">
-                            <h3 class="card-title">
-                                🎙️ Inspired to Build: Live with Gleb Lukicov
-                            </h3>
+                            <h3 class="card-title">Inspired to Build: Live with Gleb Lukicov</h3>
                             <p class="card-text">
                                 Live conversation with Erica Hughberg about
-                                scaling MLOps at Electric Twin and what inspired
-                                my journey into data & AI.
+                                scaling MLOps at Electric Twin, where I was
+                                founding MLOps engineer, and what inspired my
+                                journey into data and AI.
                             </p>
-                            <a
-                                href="https://www.youtube.com/live/Zv5CWN5Dp9A"
-                                target="_blank"
-                                class="card-link"
-                                >Watch on YouTube</a
-                            >
+                            <div class="card-actions">
+                                <a
+                                    href="https://www.youtube.com/live/Zv5CWN5Dp9A"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="card-link"
+                                    >Watch on YouTube</a
+                                >
+                            </div>
                         </div>
-                    </div>
+                    </article>
                 </div>
 
-                <!-- Resources -->
                 <div class="card mt-3">
                     <div class="card-content">
-                        <h3 class="card-title">
-                            Some great resources that helped me on my data
-                            science and ML journey
-                        </h3>
-                        <p class="card-text"></p>
-                        <b>Technical</b>:
-                        <ul style="list-style-type: none; margin-left: 0">
-                            <li
-                                style="
-                                    margin-bottom: 10px;
-                                    padding-left: 30px;
-                                    position: relative;
-                                "
-                            >
-                                <span style="position: absolute; left: 0"
-                                    >📚</span
-                                >
-                                <a
-                                    href="https://www.packtpub.com/en-us/product/clean-code-in-python-9781800560215"
-                                    target="_blank"
-                                    ><i>Clean Code in Python</i> by Mariano
-                                    Anaya</a
-                                >. A modern and practical guide to writing good
-                                code 👌.
-                            </li>
-                            <li
-                                style="
-                                    margin-bottom: 10px;
-                                    padding-left: 30px;
-                                    position: relative;
-                                "
-                            >
-                                <span style="position: absolute; left: 0"
-                                    >📚</span
-                                >
-                                <a
-                                    href="https://www.packtpub.com/en-gb/product/machine-learning-engineering-with-python-9781837631964"
-                                    target="_blank"
-                                    ><i
-                                        >Machine Learning Engineering with
-                                        Python</i
-                                    >
-                                    by Andrew McMahon</a
-                                >. MLOps in action with practical examples.
-                            </li>
-                            <li
-                                style="
-                                    margin-bottom: 10px;
-                                    padding-left: 30px;
-                                    position: relative;
-                                "
-                            >
-                                <span style="position: absolute; left: 0"
-                                    >📚</span
-                                >
-                                <a
-                                    href="https://www.packtpub.com/en-gb/product/llm-engineers-handbook-9781836200079"
-                                    target="_blank"
-                                    ><i>LLM Engineer's Handbook</i> by Paul
-                                    Iusztin and Maxime Labonne</a
-                                >, which is accompanied by well-structured
-                                <a
-                                    href="https://github.com/PacktPublishing/LLM-Engineers-Handbook"
-                                    target="_blank"
-                                >
-                                    exercises</a
-                                >.
-                            </li>
-                            <li
-                                style="
-                                    margin-bottom: 10px;
-                                    padding-left: 30px;
-                                    position: relative;
-                                "
-                            >
-                                <span style="position: absolute; left: 0"
-                                    >📚</span
-                                >
-                                <a
-                                    href="https://www.oreilly.com/library/view/ai-engineering/9781098166298/"
-                                    target="_blank"
-                                    ><i>AI Engineering</i> by Chip Huyen</a
-                                >, with many rules-of-thumb for building AI
-                                systems. Chip also maintains an excellent
-                                <a
-                                    href="https://huyenchip.com/mlops/"
-                                    target="_blank"
-                                    >collection of MLOps materials</a
-                                >.
-                            </li>
-                            <b>Career:</b>
-                            <li
-                                style="
-                                    margin-bottom: 10px;
-                                    padding-left: 30px;
-                                    position: relative;
-                                "
-                            >
-                                <span style="position: absolute; left: 0"
-                                    >📚</span
-                                >
-                                <a
-                                    href="https://www.manning.com/books/build-a-career-in-data-science"
-                                    target="_blank"
-                                    ><i>Build a Career in Data Science</i> by
-                                    Emily Robinson and Jacqueline Nolis</a
-                                >. This excellent book covers interview
-                                preparation and how to grow in your new data
-                                science role. Emily and Jacqueline also host a
-                                <a
-                                    href="https://podcast.bestbook.cool/"
-                                    target="_blank"
-                                    >podcast on the very same topic!</a
-                                >
-                            </li>
-                            <li
-                                style="
-                                    margin-bottom: 10px;
-                                    padding-left: 30px;
-                                    position: relative;
-                                "
-                            >
-                                <span style="position: absolute; left: 0">
-                                    ✉️
-                                </span>
-                                <a
-                                    href="https://levelupwithethanevans.substack.com/"
-                                    target="_blank"
-                                    ><i>Level Up</i> by Ethan Evans</a
-                                >. Ethan, an ex-VP at Amazon, shares his
-                                insights into taking control of your career and
-                                how to become an effective leader.
-                            </li>
-                        </ul>
+                        <h3 class="card-title">Resources that helped on the journey</h3>
+                        <div class="resources">
+                            <div class="resource-col">
+                                <h4>Technical</h4>
+                                <ul>
+                                    <li>
+                                        <span class="mark" aria-hidden="true">📚</span>
+                                        <a href="https://www.packtpub.com/en-us/product/clean-code-in-python-9781800560215" target="_blank" rel="noopener noreferrer"><i>Clean Code in Python</i> by Mariano Anaya</a>.
+                                        A modern and practical guide to writing good code.
+                                    </li>
+                                    <li>
+                                        <span class="mark" aria-hidden="true">📚</span>
+                                        <a href="https://www.packtpub.com/en-gb/product/machine-learning-engineering-with-python-9781837631964" target="_blank" rel="noopener noreferrer"><i>Machine Learning Engineering with Python</i> by Andrew McMahon</a>.
+                                        MLOps in action with practical examples.
+                                    </li>
+                                    <li>
+                                        <span class="mark" aria-hidden="true">📚</span>
+                                        <a href="https://www.packtpub.com/en-gb/product/llm-engineers-handbook-9781836200079" target="_blank" rel="noopener noreferrer"><i>LLM Engineer’s Handbook</i> by Paul Iusztin and Maxime Labonne</a>,
+                                        with well-structured
+                                        <a href="https://github.com/PacktPublishing/LLM-Engineers-Handbook" target="_blank" rel="noopener noreferrer">exercises</a>.
+                                    </li>
+                                    <li>
+                                        <span class="mark" aria-hidden="true">📚</span>
+                                        <a href="https://www.oreilly.com/library/view/ai-engineering/9781098166298/" target="_blank" rel="noopener noreferrer"><i>AI Engineering</i> by Chip Huyen</a>,
+                                        with many rules of thumb for building AI systems. Chip also maintains an excellent
+                                        <a href="https://huyenchip.com/mlops/" target="_blank" rel="noopener noreferrer">collection of MLOps materials</a>.
+                                    </li>
+                                </ul>
+                            </div>
+                            <div class="resource-col">
+                                <h4>Career</h4>
+                                <ul>
+                                    <li>
+                                        <span class="mark" aria-hidden="true">📚</span>
+                                        <a href="https://www.manning.com/books/build-a-career-in-data-science" target="_blank" rel="noopener noreferrer"><i>Build a Career in Data Science</i> by Emily Robinson and Jacqueline Nolis</a>.
+                                        Interview preparation and how to grow in a new data science role.
+                                    </li>
+                                    <li>
+                                        <span class="mark" aria-hidden="true">✉️</span>
+                                        <a href="https://levelupwithethanevans.substack.com/" target="_blank" rel="noopener noreferrer"><i>Level Up</i> by Ethan Evans</a>.
+                                        An ex-VP at Amazon on taking control of your career and becoming an effective leader.
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
         </section>
 
-        <!-- Research Section -->
         <section class="section" id="research">
             <div class="container section-content">
-                <h2 class="section-title">Research overview 🔬</h2>
+                <h2 class="section-title">Research</h2>
 
-                <div class="card mb-3">
+                <article class="card mb-3">
                     <div class="card-content">
                         <h3 class="card-title">The experiment</h3>
                         <p class="card-text">
@@ -1361,8 +1604,9 @@
                             <a
                                 href="https://www.bbc.co.uk/news/science-environment-66407099"
                                 target="_blank"
-                                >discovered a tantalising sign of New Physics (a
-                                new force of nature!)</a
+                                rel="noopener noreferrer"
+                                >found a tantalising sign of New Physics (a new
+                                force of nature!)</a
                             >. This was done by measuring a deviation between
                             the experimental and theoretically predicted value
                             of the muon magnetic anomaly. As part of my PhD, I
@@ -1372,33 +1616,31 @@
                             <a
                                 href="https://www.ucl.ac.uk/news/2026/apr/ucl-physicists-share-prestigious-breakthrough-prize-muon-experiment"
                                 target="_blank"
+                                rel="noopener noreferrer"
                                 >Breakthrough Prize in Fundamental Physics</a
                             >.
                         </p>
-                        <div
-                            class="iframe-container video-embed breakthrough-video mt-3"
+                        <button
+                            type="button"
+                            class="media-16x9 video-poster mt-3"
+                            data-youtube="GyWJ_dLydPE"
+                            data-title="Muon g − 2 wins Breakthrough Prize in Fundamental Physics"
+                            aria-label="Play video: Muon g − 2 Breakthrough Prize"
                         >
-                            <iframe
-                                src="https://www.youtube.com/embed/GyWJ_dLydPE?feature=oembed"
-                                title="Muon g-2 wins Breakthrough Prize in Fundamental Physics"
-                                allow="
-                                    accelerometer;
-                                    autoplay;
-                                    clipboard-write;
-                                    encrypted-media;
-                                    gyroscope;
-                                    picture-in-picture;
-                                    web-share;
-                                "
-                                referrerpolicy="strict-origin-when-cross-origin"
-                                allowfullscreen
-                            ></iframe>
-                        </div>
+                            <img
+                                src="https://i.ytimg.com/vi/GyWJ_dLydPE/hqdefault.jpg"
+                                alt="Video thumbnail: Muon g − 2 Breakthrough Prize"
+                                loading="lazy"
+                            />
+                            <span class="play-btn" aria-hidden="true"
+                                ><i class="fas fa-play"></i
+                            ></span>
+                        </button>
                     </div>
-                </div>
+                </article>
 
                 <div class="grid grid-2">
-                    <div class="card">
+                    <article class="card">
                         <div class="card-content">
                             <h3 class="card-title">Software development</h3>
                             <p class="card-text">
@@ -1408,473 +1650,442 @@
                                 <a
                                     href="https://github.com/glukicov/alignTrack"
                                     target="_blank"
-                                >
-                                    <i class="fab fa-github"></i> developing,
-                                    testing and deploying the calibration
-                                    software framework </a
+                                    rel="noopener noreferrer"
+                                    >developing, testing and deploying the
+                                    calibration software framework</a
                                 >, which increased the yield of data by 3% and
                                 the data quality by 4%. The alignment procedure
                                 is a statistical problem, which involved the
                                 optimisation of the <i>p</i>-values of tracks
                                 via matrix inversion.
                             </p>
-                            <a
-                                href="https://github.com/glukicov/alignTrack"
-                                target="_blank"
-                                class="card-link"
-                                >View on GitHub</a
-                            >
+                            <div class="card-actions">
+                                <a
+                                    href="https://github.com/glukicov/alignTrack"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="card-link"
+                                    >View on GitHub</a
+                                >
+                            </div>
                         </div>
-                    </div>
+                    </article>
 
-                    <div class="card">
+                    <article class="card">
                         <div class="card-content">
                             <h3 class="card-title">Data analysis</h3>
                             <p class="card-text">
-                                There is also an additional measurement that
-                                will be made using the tracking detectors:
-                                setting a new limit on the electric dipole
-                                moment (EDM) of the muon, producing a
-                                world-leading result. I have been
+                                An additional measurement using the tracking
+                                detectors is a search for the electric dipole
+                                moment (EDM) of the muon. I
                                 <a
                                     href="https://github.com/glukicov/EDMTracking"
                                     target="_blank"
+                                    rel="noopener noreferrer"
+                                    >developed algorithms to measure the muon
+                                    EDM</a
                                 >
-                                    <i class="fab fa-github"></i> developing
-                                    algorithms to measure the muon EDM </a
-                                >, by analysing large and complex datasets using
+                                by analysing large and complex datasets using
                                 regression and Fourier transform methods.
                             </p>
-                            <a
-                                href="https://github.com/glukicov/EDMTracking"
-                                target="_blank"
-                                class="card-link"
-                                >View on GitHub</a
-                            >
+                            <div class="card-actions">
+                                <a
+                                    href="https://github.com/glukicov/EDMTracking"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="card-link"
+                                    >View on GitHub</a
+                                >
+                            </div>
                         </div>
-                    </div>
+                    </article>
                 </div>
 
                 <div class="grid grid-2 mt-3">
-                    <div class="card">
-                        <img
-                            src="./images/APS_DPF_2019.JPG"
-                            alt="Presenting at the American Physical Society conference"
-                            style="width: 100%"
-                        />
-                        <div class="card-content">
-                            Presenting at the American Physical Society
-                            conference in Boston.
-                            <a
-                                href="https://indico.cern.ch/event/782953/contributions/3441653/attachments/1885766/3108628/APS_DPF_Gleb_Lukicov.pdf"
-                                target="_blank"
-                                >My talk</a
-                            >
-                            highlighted the significance of precise tracking
-                            systems in high-energy physics experiments and their
-                            role in probing fundamental particle properties.
+                    <article class="card">
+                        <div class="media-16x9">
+                            <img
+                                src="./images/APS_DPF_2019.JPG"
+                                alt="Gleb presenting at the American Physical Society conference in Boston"
+                                loading="lazy"
+                            />
                         </div>
-                    </div>
+                        <div class="card-content">
+                            <p class="card-text">
+                                Presenting at the American Physical Society
+                                conference in Boston.
+                                <a
+                                    href="https://indico.cern.ch/event/782953/contributions/3441653/attachments/1885766/3108628/APS_DPF_Gleb_Lukicov.pdf"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    >My talk</a
+                                >
+                                highlighted the significance of precise tracking
+                                systems in high-energy physics experiments and
+                                their role in probing fundamental particle
+                                properties.
+                            </p>
+                        </div>
+                    </article>
 
-                    <div class="card">
-                        <img src="./images/plot.png" />
+                    <article class="card">
+                        <div class="media-16x9">
+                            <img
+                                src="./images/plot.png"
+                                alt="Plot from muon g − 2 tracking analysis"
+                                loading="lazy"
+                            />
+                        </div>
                         <div class="card-content">
                             <h3 class="card-title">Selected written work</h3>
-                            <ul style="list-style-type: none; margin-left: 0">
-                                <li
-                                    style="
-                                        margin-bottom: 10px;
-                                        padding-left: 30px;
-                                        position: relative;
-                                    "
-                                >
-                                    <span style="position: absolute; left: 0">
-                                        📝
-                                    </span>
-                                    <a
-                                        href="files/PhDThesis_Gleb_Lukicov.pdf"
-                                        target="_blank"
-                                        >PhD thesis</a
-                                    >
+                            <ul class="plain-list">
+                                <li>
+                                    <a href="files/PhDThesis_Gleb_Lukicov.pdf" target="_blank" rel="noopener noreferrer">PhD thesis</a>
                                 </li>
-                                <li
-                                    style="
-                                        margin-bottom: 10px;
-                                        padding-left: 30px;
-                                        position: relative;
-                                    "
-                                >
-                                    <span style="position: absolute; left: 0">
-                                        📝</span
-                                    >
-                                    <a
-                                        href="https://arxiv.org/pdf/1909.12900.pdf"
-                                        target="_blank"
-                                        >Publication: calibration
-                                        (arXiv:1909.12900)</a
-                                    >
+                                <li>
+                                    <a href="https://doi.org/10.1103/PhysRevLett.131.161802" target="_blank" rel="noopener noreferrer">Measurement of the Positive Muon Anomalous Magnetic Moment to 0.20 ppm</a>,
+                                    PRL 131, 161802 (Aug 2023)
                                 </li>
-                                <li
-                                    style="
-                                        margin-bottom: 10px;
-                                        padding-left: 30px;
-                                        position: relative;
-                                    "
-                                >
-                                    <span style="position: absolute; left: 0">
-                                        📝</span
-                                    >
-                                    <a
-                                        href="https://indico.cern.ch/event/782953/contributions/3441653/attachments/1885766/3108628/APS_DPF_Gleb_Lukicov.pdf"
-                                        target="_blank"
-                                        >Conference talk: data analysis</a
-                                    >
+                                <li>
+                                    <a href="https://doi.org/10.1103/PhysRevLett.126.141801" target="_blank" rel="noopener noreferrer">Measurement of the Positive Muon Anomalous Magnetic Moment to 0.46 ppm</a>,
+                                    PRL 126, 141801 (Apr 2021)
                                 </li>
-                                <li
-                                    style="
-                                        margin-bottom: 10px;
-                                        padding-left: 30px;
-                                        position: relative;
-                                    "
-                                >
-                                    <span style="position: absolute; left: 0">
-                                        📝</span
-                                    >
-                                    <a
-                                        href="https://lss.fnal.gov/archive/2019/poster/fermilab-poster-19-011-e.pdf"
-                                        target="_blank"
-                                        >Conference poster: calibration</a
-                                    >
+                                <li>
+                                    <a href="https://arxiv.org/abs/1909.12900" target="_blank" rel="noopener noreferrer">Calibration paper (arXiv:1909.12900)</a>
                                 </li>
-                                <li
-                                    style="
-                                        margin-bottom: 10px;
-                                        padding-left: 30px;
-                                        position: relative;
-                                    "
-                                >
-                                    <span style="position: absolute; left: 0">
-                                        📝</span
-                                    >
-                                    <a
-                                        href="files/Proposal_GlebLukicov.pdf"
-                                        target="_blank"
-                                        >Project proposal</a
-                                    >
+                                <li>
+                                    <a href="https://indico.cern.ch/event/782953/contributions/3441653/attachments/1885766/3108628/APS_DPF_Gleb_Lukicov.pdf" target="_blank" rel="noopener noreferrer">Conference talk: data analysis</a>
+                                </li>
+                                <li>
+                                    <a href="https://lss.fnal.gov/archive/2019/poster/fermilab-poster-19-011-e.pdf" target="_blank" rel="noopener noreferrer">Conference poster: calibration</a>
+                                </li>
+                                <li>
+                                    <a href="files/Proposal_GlebLukicov.pdf" target="_blank" rel="noopener noreferrer">Project proposal</a>
                                 </li>
                             </ul>
                         </div>
-                    </div>
+                    </article>
                 </div>
 
-                <div class="card mt-3">
+                <article class="card mt-3">
                     <div class="card-content">
                         <h3 class="card-title">Data collection</h3>
-                        <p class="card-text">
+                        <p class="card-text mb-0">
                             An essential component of the experiment is the data
                             acquisition (DAQ) system, which manages the data
                             flow from the detector electronics. The experiment
-                            is acquiring raw data at a rate of 20 GB/s. This is
-                            accomplished by employing a parallel data processing
-                            architecture using 28 high-speed GPUs (<i
-                                >NVIDIA Tesla K40</i
-                            >), reducing the recorded data rate to 200 MB/s. To
-                            support the smooth operation of the experiment and
-                            ensure continuous data taking, a team of data
-                            acquisition (DAQ) experts are available for 24/7
-                            support.
+                            acquired raw data at a rate of 20 GB/s, using a
+                            parallel data processing architecture with 28
+                            high-speed GPUs (<i>NVIDIA Tesla K40</i>) and
+                            reducing the recorded data rate to 200 MB/s. To
+                            support continuous data taking, a team of DAQ
+                            experts provided 24/7 support.
                             <a
                                 href="files/Proposal_GlebLukicov.pdf"
                                 target="_blank"
-                                >I have actively participated as the DAQ on-call
-                                computing expert between 2017 and 2019</a
+                                rel="noopener noreferrer"
+                                >I participated as the DAQ on-call computing
+                                expert between 2017 and 2019</a
                             >.
                         </p>
                     </div>
-                </div>
+                </article>
             </div>
         </section>
 
-        <!-- Education Section -->
-        <section class="section" id="outreach">
+        <section class="section alt" id="outreach">
             <div class="container section-content">
-                <h2 class="section-title">Education projects 🔭</h2>
+                <h2 class="section-title">Outreach</h2>
 
                 <div class="grid grid-2">
-                    <div class="card">
-                        <img
-                            src="./images/gleb19.jpg"
-                            alt="Alumni Talk"
-                            style="width: 100%"
-                        />
+                    <article class="card">
+                        <div class="media-16x9">
+                            <img
+                                src="./images/gleb19.jpg"
+                                alt="Gleb delivering an alumni talk at Woodhouse College"
+                                loading="lazy"
+                            />
+                        </div>
                         <div class="card-content">
-                            <p class="card-text">
-                                Delivering an alumni talk at the Woodhouse
-                                College 🎓 about my all-time favourite particle
-                                -
-                                <a
-                                    href="https://en.wikipedia.org/wiki/Muon"
-                                    target="_blank"
-                                    >the muon</a
-                                >
-                                - and how it can be used for
-                                <a
-                                    href="https://www.nature.com/news/cosmic-ray-particles-reveal-secret-chamber-in-egypt-s-great-pyramid-1.22939"
-                                    target="_blank"
-                                    >treasure-hunting 👑</a
-                                >,
-                                <a
-                                    href="https://cms.cern/content/security-and-environmental-protection"
-                                    target="_blank"
-                                    >making borders more secure 👮‍♀️</a
-                                >, and
-                                <a
-                                    href="https://muon-g-2.fnal.gov/muon-g-2-collaboration-to-solve-mystery.html"
-                                    target="_blank"
-                                    >unlocking the mysteries of the Universe
-                                    🔎</a
-                                >. I come back to the college every year to
-                                encourage students in pursuing a career in STEM.
+                            <p class="card-text mb-0">
+                                Delivering an alumni talk at Woodhouse College
+                                about my all-time favourite particle —
+                                <a href="https://en.wikipedia.org/wiki/Muon" target="_blank" rel="noopener noreferrer">the muon</a>
+                                — and how it can be used for
+                                <a href="https://www.nature.com/news/cosmic-ray-particles-reveal-secret-chamber-in-egypt-s-great-pyramid-1.22939" target="_blank" rel="noopener noreferrer">treasure-hunting</a>,
+                                <a href="https://cms.cern/content/security-and-environmental-protection" target="_blank" rel="noopener noreferrer">making borders more secure</a>,
+                                and
+                                <a href="https://muon-g-2.fnal.gov/muon-g-2-collaboration-to-solve-mystery.html" target="_blank" rel="noopener noreferrer">unlocking the mysteries of the Universe</a>.
+                                I come back to the college every year to
+                                encourage students pursuing a career in STEM.
                             </p>
                         </div>
-                    </div>
+                    </article>
 
-                    <div class="card">
-                        <img
-                            src="./images/tour.jpg"
-                            alt="Fermilab Tour"
-                            style="width: 100%"
-                        />
+                    <article class="card">
+                        <div class="media-16x9">
+                            <img
+                                src="./images/tour.jpg"
+                                alt="Gleb guiding a public tour of the Fermilab muon g − 2 experiment"
+                                loading="lazy"
+                            />
+                        </div>
                         <div class="card-content">
-                            <p class="card-text">
+                            <p class="card-text mb-0">
                                 Guiding a public tour of the
-                                <a
-                                    href="https://en.wikipedia.org/wiki/Muon_g-2"
-                                    target="_blank"
-                                    >Fermilab Muon g &mdash; 2 experiment</a
-                                >. The experiment has measured an anomaly in a
+                                <a href="https://en.wikipedia.org/wiki/Muon_g-2" target="_blank" rel="noopener noreferrer">Fermilab Muon <i>g − 2</i> experiment</a>.
+                                The experiment measured an anomaly in a
                                 property of a fundamental particle, expanding
                                 our knowledge of the Universe and providing
                                 evidence of the existence of new particles.
                             </p>
                         </div>
-                    </div>
+                    </article>
                 </div>
 
                 <div class="grid grid-2 mt-3">
-                    <div class="card">
-                        <a
-                            href="https://medium.com/p/9f87a8e5f92e"
-                            target="_blank"
-                        >
+                    <article class="card">
+                        <div class="media-16x9">
                             <img
-                                src="./images/spv.png"
-                                alt="Medium Article"
-                                style="width: 100%"
+                                src="./images/gleb2.png"
+                                alt="Gleb explaining spectroscopy at the Your Universe festival"
+                                loading="lazy"
                             />
-                        </a>
-                        <div class="card-content">
-                            <p class="card-text">
-                                I wrote an article about building a personal
-                                Bitcoin access point with Raspberry Pi. Read to
-                                learn about using an Electrum node for
-                                interacting with the decentralised blockchain
-                                network.
-                            </p>
-                            <a
-                                href="https://medium.com/p/9f87a8e5f92e"
-                                target="_blank"
-                                class="card-link"
-                                >Read on Medium</a
-                            >
                         </div>
-                    </div>
-
-                    <div class="card">
-                        <img
-                            src="./images/gleb2.png"
-                            alt="Your Universe Festival"
-                            style="width: 100%"
-                        />
                         <div class="card-content">
-                            <p class="card-text">
-                                Explaining spectroscopy 🔭 to primary school
+                            <p class="card-text mb-0">
+                                Explaining spectroscopy to primary school
                                 students at the
-                                <a
-                                    href="https://www.ucl.ac.uk/youruniverse"
-                                    target="_blank"
-                                    >Your Universe</a
-                                >
+                                <a href="https://www.ucl.ac.uk/youruniverse" target="_blank" rel="noopener noreferrer">Your Universe</a>
                                 astronomy festival at UCL. I was involved with
-                                the festival between 2010 and 2015. Every year,
-                                I was able to deliver educational activities to
-                                300 pupils. I also had a chance to meet
-                                <a
-                                    href="https://www.findingpatterns.info/about-me"
-                                    target="_blank"
-                                    >Geraldine Cox</a
-                                >
+                                the festival between 2010 and 2015. Every year I
+                                delivered educational activities to about 300
+                                pupils, and I had a chance to meet
+                                <a href="https://www.findingpatterns.info/about-me" target="_blank" rel="noopener noreferrer">Geraldine Cox</a>
                                 during the festival.
                             </p>
                         </div>
-                    </div>
+                    </article>
                 </div>
             </div>
         </section>
 
-        <!-- Interests Section -->
         <section class="section" id="interests">
             <div class="container section-content">
-                <h2 class="section-title">Personal interests 🚴‍♂️️</h2>
+                <h2 class="section-title">Interests</h2>
 
                 <div class="grid grid-2">
-                    <div class="card">
-                        <img
-                            src="./images/gleb-big-ride.JPEG"
-                            alt="Charity Marathon"
-                            style="width: 100%"
-                        />
+                    <article class="card">
+                        <div class="media-16x9">
+                            <img
+                                src="./images/gleb-big-ride.JPEG"
+                                alt="Gleb on a charity mountain ride and marathon"
+                                loading="lazy"
+                            />
+                        </div>
                         <div class="card-content">
-                            <p class="card-text">
-                                As part of a charity fundraising, I ran my first
-                                full marathon 🏃‍♂ (5:31 / 1 km elevation) and
-                                cycled 100 km 🚴 (4:44 / 2 km elevation). This
-                                motivated me all the way (twice!) to the top of
-                                that mountain, and
-                                <a
-                                    href="https://www.justgiving.com/team/aads-vmo2"
-                                    target="_blank"
-                                    >our team manged to fundraise £2.3K for
-                                    Street Child</a
-                                >.
+                            <p class="card-text mb-0">
+                                As part of a charity fundraiser, I ran my first
+                                full marathon (5:31 / 1 km elevation) and cycled
+                                100 km (4:44 / 2 km elevation). That motivated
+                                me all the way (twice!) to the top of that
+                                mountain, and
+                                <a href="https://www.justgiving.com/team/aads-vmo2" target="_blank" rel="noopener noreferrer">our team managed to fundraise £2.3K for Street Child</a>.
                             </p>
                         </div>
-                    </div>
+                    </article>
 
-                    <div class="card">
-                        <img
-                            src="./images/gleb-big-ride-2.JPEG"
-                            alt="Charity Cycling"
-                            style="width: 100%"
-                        />
+                    <article class="card">
+                        <div class="media-16x9">
+                            <img
+                                src="./images/gleb-big-ride-2.JPEG"
+                                alt="Gleb cycling in the Netherlands on a charity ride"
+                                loading="lazy"
+                            />
+                        </div>
                         <div class="card-content">
-                            <p class="card-text">
-                                Next year, our team was back at it! With a mini
-                                tour-of-Netherlands: 🚴 160 km day 1 (6:28 / 0.8
-                                km elevation) and 🚴 175 km day 2 (6:37 / 1.1 km
-                                elevation). This time,
-                                <a
-                                    href="https://www.justgiving.com/team/aads-2023"
-                                    target="_blank"
-                                    >we have raised £3.8K for Street Child</a
-                                >.
+                            <p class="card-text mb-0">
+                                Next year, our team was back at it — a mini
+                                tour of the Netherlands: 160 km day 1 (6:28 /
+                                0.8 km elevation) and 175 km day 2 (6:37 / 1.1
+                                km elevation). This time
+                                <a href="https://www.justgiving.com/team/aads-2023" target="_blank" rel="noopener noreferrer">we raised £3.8K for Street Child</a>.
                             </p>
                         </div>
-                    </div>
+                    </article>
+                </div>
+
+                <div class="grid grid-2 mt-3">
+                    <article class="card">
+                        <a
+                            href="https://medium.com/p/9f87a8e5f92e"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            class="media-16x9"
+                        >
+                            <img
+                                src="./images/spv.png"
+                                alt="Raspberry Pi Bitcoin access point"
+                                loading="lazy"
+                            />
+                        </a>
+                        <div class="card-content">
+                            <h3 class="card-title">Bitcoin access point on a Raspberry Pi</h3>
+                            <p class="card-text">
+                                I wrote about building a personal Bitcoin access
+                                point with a Raspberry Pi, using an Electrum
+                                node to interact with the decentralised
+                                blockchain network.
+                            </p>
+                            <div class="card-actions">
+                                <a
+                                    href="https://medium.com/p/9f87a8e5f92e"
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    class="card-link"
+                                    >Read on Medium</a
+                                >
+                            </div>
+                        </div>
+                    </article>
                 </div>
             </div>
         </section>
+        </main>
 
-        <!-- Footer -->
         <footer class="footer">
             <div class="container footer-content">
                 <div class="social-links footer-social-links">
                     <a
                         href="https://www.linkedin.com/in/glukicov"
                         target="_blank"
+                        rel="noopener noreferrer"
                         class="social-link"
-                        title="LinkedIn"
+                        aria-label="Gleb Lukicov on LinkedIn"
                     >
-                        <i class="fab fa-linkedin-in"></i>
+                        <i class="fab fa-linkedin-in" aria-hidden="true"></i>
                     </a>
                     <a
                         href="https://github.com/glukicov"
                         target="_blank"
+                        rel="noopener noreferrer"
                         class="social-link"
-                        title="GitHub"
+                        aria-label="Gleb Lukicov on GitHub"
                     >
-                        <i class="fab fa-github"></i>
+                        <i class="fab fa-github" aria-hidden="true"></i>
                     </a>
                     <a
                         href="https://medium.com/@lukicov"
                         target="_blank"
+                        rel="noopener noreferrer"
                         class="social-link"
-                        title="Medium"
+                        aria-label="Gleb Lukicov on Medium"
                     >
-                        <i class="fab fa-medium-m"></i>
+                        <i class="fab fa-medium-m" aria-hidden="true"></i>
                     </a>
                     <a
                         href="https://x.com/gleb_lukicov"
                         target="_blank"
+                        rel="noopener noreferrer"
                         class="social-link"
-                        title="X (Twitter)"
+                        aria-label="Gleb Lukicov on X"
                     >
-                        <i class="fab fa-x-twitter"></i>
+                        <i class="fab fa-x-twitter" aria-hidden="true"></i>
                     </a>
                 </div>
                 <p class="footer-text">
-                    Made with 🤠 by Gleb Lukicov · &copy; 2025
+                    Made with 🤠 by Gleb Lukicov · &copy; 2026
                 </p>
             </div>
         </footer>
 
-        <!-- Scripts -->
+        <a href="#about" class="back-to-top" id="back-to-top" aria-label="Back to top">
+            <i class="fas fa-chevron-up" aria-hidden="true"></i>
+        </a>
+
         <script>
-            // Mobile menu toggle
             document.addEventListener("DOMContentLoaded", function () {
-                const mobileMenuBtn =
-                    document.getElementById("mobile-menu-btn");
+                const mobileMenuBtn = document.getElementById("mobile-menu-btn");
                 const closeMenuBtn = document.getElementById("close-menu");
                 const nav = document.getElementById("nav");
+                const backdrop = document.getElementById("nav-backdrop");
                 const navLinks = document.querySelectorAll(".nav-link");
+                const backToTop = document.getElementById("back-to-top");
 
-                // Toggle mobile menu
-                mobileMenuBtn.addEventListener("click", function () {
+                function openMenu() {
                     nav.classList.add("active");
-                });
+                    backdrop.classList.add("active");
+                    backdrop.hidden = false;
+                    mobileMenuBtn.setAttribute("aria-expanded", "true");
+                    closeMenuBtn.focus();
+                }
 
-                closeMenuBtn.addEventListener("click", function () {
+                function closeMenu() {
                     nav.classList.remove("active");
+                    backdrop.classList.remove("active");
+                    backdrop.hidden = true;
+                    mobileMenuBtn.setAttribute("aria-expanded", "false");
+                }
+
+                mobileMenuBtn.addEventListener("click", openMenu);
+                closeMenuBtn.addEventListener("click", closeMenu);
+                backdrop.addEventListener("click", closeMenu);
+
+                navLinks.forEach(function (link) {
+                    link.addEventListener("click", closeMenu);
                 });
 
-                // Close mobile menu when clicking a link
-                navLinks.forEach((link) => {
-                    link.addEventListener("click", function () {
-                        nav.classList.remove("active");
-                    });
-                });
-
-                // Header scroll effect
-                const header = document.getElementById("header");
-                window.addEventListener("scroll", function () {
-                    if (window.scrollY > 50) {
-                        header.classList.add("scrolled");
-                    } else {
-                        header.classList.remove("scrolled");
+                document.addEventListener("keydown", function (event) {
+                    if (event.key === "Escape") {
+                        closeMenu();
                     }
                 });
 
-                // Active nav link based on scroll position
-                const sections = document.querySelectorAll("section");
-                window.addEventListener("scroll", function () {
+                const sections = document.querySelectorAll("section[id]");
+                function onScroll() {
+                    const y = window.scrollY;
+                    backToTop.classList.toggle("visible", y > 480);
+
                     let current = "";
-
-                    sections.forEach((section) => {
-                        const sectionTop = section.offsetTop;
-                        const sectionHeight = section.clientHeight;
-
-                        if (window.scrollY >= sectionTop - 200) {
+                    sections.forEach(function (section) {
+                        if (y >= section.offsetTop - 140) {
                             current = section.getAttribute("id");
                         }
                     });
 
-                    navLinks.forEach((link) => {
+                    navLinks.forEach(function (link) {
                         link.classList.remove("active");
-                        if (
-                            link.getAttribute("href").substring(1) === current
-                        ) {
+                        const href = link.getAttribute("href");
+                        if (href === "#" + current) {
                             link.classList.add("active");
                         }
+                    });
+                }
+
+                window.addEventListener("scroll", onScroll, { passive: true });
+                onScroll();
+
+                document.querySelectorAll("[data-youtube]").forEach(function (poster) {
+                    poster.addEventListener("click", function () {
+                        const id = poster.getAttribute("data-youtube");
+                        const title = poster.getAttribute("data-title") || "YouTube video";
+                        const wrap = document.createElement("div");
+                        wrap.className = poster.className.replace("video-poster", "").trim() || "media-16x9";
+                        if (!wrap.classList.contains("media-16x9")) {
+                            wrap.classList.add("media-16x9");
+                        }
+                        const iframe = document.createElement("iframe");
+                        iframe.src =
+                            "https://www.youtube-nocookie.com/embed/" +
+                            id +
+                            "?autoplay=1&rel=0";
+                        iframe.title = title;
+                        iframe.allow =
+                            "accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share";
+                        iframe.allowFullscreen = true;
+                        iframe.referrerPolicy = "strict-origin-when-cross-origin";
+                        wrap.appendChild(iframe);
+                        poster.replaceWith(wrap);
                     });
                 });
             });


### PR DESCRIPTION
## Summary
- Update copy so the site matches current public work: Agentic AI community as current, MLOps London as past, Electric Twin and Virgin Media O2 in the past tense, plus an experience timeline, education, and current certs (CKAD, MCP). Current employer is intentionally omitted.
- Restore a real H1, add Open Graph tags, a compact sticky header, olive (not maroon) nav, click-to-play video posters instead of eager embeds, `#contact`, skip link, and a 2026 footer.
- Point `contact.html` at `#contact` so the old redirect lands on the contact block.

## Test plan
- [ ] Desktop: nav stays on one row, active state is olive, sticky header does not show page text through it
- [ ] Mobile: hamburger opens with visible labels, pinch-zoom works, menu close button is named
- [ ] Hero shows name as H1, agentic AI community as current, no current employer
- [ ] Experience lists Agentic AI Foundation, MLOps Community, Electric Twin, VMO2, Fermilab (no current employer)
- [ ] YouTube posters play on click; Spotify is a link, not an embed
- [ ] `/contact.html` jumps to the contact icons
- [ ] Footer year is 2026; `podcast.bestbook.cool` is gone