### PR TITLE
Rebrand MLOps Community London to Agentic AI Foundation (AAIF) Community London

### DIFF
--- a/index.html
+++ b/index.html
@@ -924,7 +924,7 @@
                         </li>
                         <li class="nav-item">
                             <a href="#aaif-community" class="nav-link"
-                                ><i class="fas fa-users"></i> AAIF
+                                ><i class="fas fa-users"></i> MLOps
                             </a>
                         </li>
                         <li class="nav-item">

--- a/index.html
+++ b/index.html
@@ -923,8 +923,8 @@
                             </a>
                         </li>
                         <li class="nav-item">
-                            <a href="#mlops-community" class="nav-link"
-                                ><i class="fas fa-users"></i> MLOps
+                            <a href="#aaif-community" class="nav-link"
+                                ><i class="fas fa-users"></i> AAIF
                             </a>
                         </li>
                         <li class="nav-item">
@@ -972,9 +972,10 @@
                     just about tools; it's about aligning people, processes, and
                     platforms to solve real business problems.
                     <br /><br />
-                    Outside of work, I co-organise the London MLOps community —
-                    Europe's largest MLOps meetup — and love sharing what I've
-                    learned through blogging and public speaking.
+                    Outside of work, I co-organise the Agentic AI Foundation
+                    (AAIF) Community London — Europe's largest AI engineering
+                    meetup — and love sharing what I've learned through blogging
+                    and public speaking.
                     <br /><br />
                     Before entering the tech industry, I conducted scientific
                     research at world-class physics labs in the US and
@@ -1020,10 +1021,10 @@
             </div>
         </section>
 
-        <!-- MLOps Community Section -->
-        <section class="section" id="mlops-community">
+        <!-- AAIF Community Section -->
+        <section class="section" id="aaif-community">
             <div class="container section-content">
-                <h2 class="section-title">MLOps Community London <i class="fas fa-location-dot em-icon" aria-hidden="true"></i></h2>
+                <h2 class="section-title">Agentic AI Foundation (AAIF) Community London <i class="fas fa-location-dot em-icon" aria-hidden="true"></i></h2>
 
                 <div class="grid grid-2 mb-3">
                     <div class="card">
@@ -1034,7 +1035,7 @@
                             />
                             <img
                                 src="./images/gleb-mlops.png"
-                                alt="MLOps Community London"
+                                alt="Agentic AI Foundation (AAIF) Community London"
                                 style="width: 100%"
                                 loading="lazy"
                                 decoding="async"
@@ -1046,14 +1047,15 @@
                             <p class="card-text">
                                 I am actively engaged in the
                                 <a
-                                    href="https://mlops.community"
+                                    href="https://luma.com/aaif-london"
                                     target="_blank"
-                                    >MLOps Community London</a
-                                >, the largest MLOps community in Europe, as a
-                                co-host and events organiser. We are putting
-                                regular in-person meetup-ups, for the community
-                                to learn together and discuss latest MLOps
-                                trends over <i class="fas fa-pizza-slice em-icon" aria-hidden="true"></i>.
+                                    >Agentic AI Foundation (AAIF) Community
+                                    London</a
+                                >, the largest AI engineering community in
+                                Europe, as a co-host and events organiser. We are
+                                putting regular in-person meetup-ups, for the
+                                community to learn together and discuss latest
+                                agentic AI trends over <i class="fas fa-pizza-slice em-icon" aria-hidden="true"></i>.
                             </p>
                             <a
                                 href="https://luma.com/aaif-london"
@@ -1075,10 +1077,10 @@
                         ></iframe>
                         <div class="card-content">
                             <a
-                                href="https://gatewaze.mlops.community/?mode=slack#email"
+                                href="https://luma.com/aaif-london"
                                 target="_blank"
                                 class="card-link"
-                                >Join the MLOps Community</a
+                                >Join the AAIF Community</a
                             >
                         </div>
                     </div>


### PR DESCRIPTION
Renames the community section to the Agentic AI Foundation (AAIF) Community London and repoints its links.

## Changes

- **Community section**: heading, `<!-- -->` comment, section anchor `#mlops-community` → `#aaif-community`, and the image `alt` text now read "Agentic AI Foundation (AAIF) Community London".
- **Nav**: item label `MLOps` → `AAIF`, target updated to the new anchor.
- **Hero copy**: "co-organise the London MLOps community — Europe's largest MLOps meetup" → "co-organise the Agentic AI Foundation (AAIF) Community London — Europe's largest AI engineering meetup".
- **Links**: both the community link (was `https://mlops.community`) and the Join link (was `https://gatewaze.mlops.community/?mode=slack#email`) now point to `https://luma.com/aaif-london`. The events link already pointed there.
- **Body copy**: "the largest MLOps community in Europe" → "the largest AI engineering community in Europe"; "latest MLOps trends" → "latest agentic AI trends".

## Deliberately left unchanged

- The podcast card "Electric Twin &amp; MLOps Community London" and its blurb — that is the title of an already-published episode recorded under the old name.
- Gleb's personal MLOps branding (page title, meta description, logo subtitle, "To MLOps, or not to MLOps?" article) and third-party MLOps links (Medium article, huyenchip.com/mlops).
- Image filenames `images/gleb-mlops.*` — renaming is cosmetic and would need new assets.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJMjct6xwPtaEVfH2Nsm1r)_