### PR TITLE
Say "pizza" instead of the pizza icon in the AAIF community copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -1077,7 +1077,7 @@
                                 Europe, as a co-host and events organiser. We are
                                 putting regular in-person meetup-ups, for the
                                 community to learn together and discuss latest
-                                agentic AI trends over <i class="fas fa-pizza-slice em-icon" aria-hidden="true"></i>.
+                                agentic AI trends over pizza.
                             </p>
                             <a
                                 href="https://luma.com/aaif-london"


### PR DESCRIPTION
Small copy fix in the Agentic AI Foundation (AAIF) Community London section.

## Changes

- `index.html`: the sentence now ends "…discuss latest agentic AI trends over pizza." The decorative `fa-pizza-slice` icon (which was `aria-hidden`, so it read as "…trends over ." to screen readers) is removed in favour of the word.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EJMjct6xwPtaEVfH2Nsm1r)_