### PR TITLE
Design review, seven variants, and a preview bundler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .idea
+__pycache__/

--- a/DESIGN-VARIANTS.md
+++ b/DESIGN-VARIANTS.md
@@ -146,3 +146,50 @@ turns any variant's `index.html` into a single self-contained file (images
 inlined, embeds replaced by poster facades because the private preview host
 blocks third-party frames) which is what the private preview links show.
 The real branch keeps the live embeds.
+
+## Results
+
+All seven are built, committed and pushed. Each preview is a private,
+self-contained page: images inlined, Font Awesome inlined where the variant
+still uses it, and the six third-party embeds replaced by poster facades that
+link out, because the preview host admits only the page's own bytes. The
+branches keep the real live embeds.
+
+Baseline, the current site bundled the same way for like-for-like comparison:
+https://claude.ai/code/artifact/be581439-5435-40a5-a175-0597ee4e4148
+
+| Variant | Branch suffix | First load | Preview |
+|---|---|---|---|
+| v01 Tune-up | `-v01-tune-up` | 1,250 → 492 KB (−61 % above the fold) | https://claude.ai/code/artifact/8f02c677-77a5-4c43-a028-0a8cee595924 |
+| v02 Motion | `-v02-motion` | 905 → 448 KB (−49 %) | https://claude.ai/code/artifact/c6d466d5-4a66-4d6e-b277-2d7955d77e21 |
+| v03 Editorial | `-v03-editorial` | 1,383 → 167 KB (−88 %) | https://claude.ai/code/artifact/59e03d3d-363b-4729-8719-d07d2b0b1659 |
+| v04 Bento | `-v04-bento` | 1,383 → 221 KB (−84 %) | https://claude.ai/code/artifact/4ad255ce-b9bb-468a-b547-30b4a8cde02b |
+| v05 Timeline | `-v05-timeline` | 1,383 → 235 KB (−83 %) | https://claude.ai/code/artifact/b1b04918-f986-4f6d-9cde-84d145f13e6a |
+| v06 Pipeline | `-v06-pipeline` | 927 → 173 KB (−81 %) | https://claude.ai/code/artifact/16cb20b8-9e22-4424-86db-24fc14faa26c |
+| v07 Muon | `-v07-muon` | 2,039 → 1,323 KB whole page (−35 %) | https://claude.ai/code/artifact/00c4ce57-5232-45ba-b750-539d75e45a2b |
+
+Branches are `claude/website-design-variants-ff49ga` + the suffix above. Each
+carries its own `VARIANT.md` with the design plan, the change list, measured
+numbers and the exclusions its author chose.
+
+First-load figures come from each variant's own measurement of first-party
+bytes with third-party embeds excluded, so they are comparable within a
+variant's before/after pair rather than across rows: the baselines differ
+(some agents measured at 1440 px desktop, some counted the animated hero
+background differently). The direction and rough magnitude hold everywhere.
+
+### Things worth knowing whichever variant wins
+
+- The 489 KB `images/icon.png` serving a 40 px logo is the single biggest
+  easy win, and every variant removes it.
+- The sticky header's `backdrop-filter` makes the header the containing block
+  for its own fixed-position descendants, so the mobile drawer opens clipped
+  to the header strip. Three variants hit this independently and fixed it by
+  moving the frosted layer to a `::before`. It is worth checking on the live
+  site.
+- The `.card { height: 100% }` rule is harmless in standards mode but clips
+  content in quirks mode. It only matters if a page ever loses its doctype,
+  which is what happened in an early build of `tools/preview_bundle.py`.
+- Nothing here has been seen with its real display faces. The build
+  environment cannot reach `fonts.googleapis.com`, so every screenshot fell
+  back to system fonts. Check the type once the variants are served for real.

--- a/DESIGN-VARIANTS.md
+++ b/DESIGN-VARIANTS.md
@@ -1,0 +1,148 @@
+# Design variants — plan and review notes
+
+Live site: https://glukicov.github.io (byte-identical to `index.html` on master at the time of review).
+Reviewed on 2026-09-01 at 1440×900 and 390×844, plus a read of the markup and CSS.
+
+## What is there today
+
+A single-page portfolio: fixed header with six nav links, a hero with a
+network-graph animation behind three centred paragraphs, then five sections
+(AAIF Community, ML projects and articles, Research, Education, Interests)
+rendered as a uniform two-column card grid, and a footer. Noir ground
+(`#0b0c0e`), moss accent (`#a8b33e`), Inter + JetBrains Mono, Font Awesome 6.
+All CSS and JS are inline in `index.html` (~95 KB). Photos are WebP inside
+`<picture>` with lazy loading and intrinsic sizes.
+
+### Findings
+
+Performance and loading
+
+1. `images/icon.png` (489 KB, same pixels as `main.png`) is both the favicon and
+   the 40 px header logo. Half a megabyte for a 40 px circle, on every visit.
+2. Font Awesome 6 is loaded whole from cdnjs (CSS + ~200 KB of woff2) for about
+   30 glyphs, and the stylesheet is render-blocking.
+3. Google Fonts CSS is render-blocking; there is no `preload` for the hero
+   photo or the animated hero background (269 KB WebP).
+4. Six third-party iframes (LinkedIn, Spotify, four YouTube) load eagerly on
+   first paint. Owner's choice (see CARRYOVER.md), but `loading="lazy"` on the
+   below-the-fold ones keeps them click-free while removing them from the
+   critical path.
+5. Repository dead weight that is never requested by the page: the original
+   HTML5 UP "Prologue" template (`assets/`, 3 MB) and the PNG/JPEG fallbacks
+   behind every `<picture>` (7.6 MB). WebP has been universally supported since
+   2020. Not a runtime cost, but a clone/maintenance cost.
+6. No Open Graph / Twitter card metadata, so a LinkedIn or X share of the site
+   shows a bare link. For someone who organises Europe's largest AI meetup,
+   this is the most visible missing piece.
+
+Mobile
+
+7. The hero is three long centred paragraphs. Centred body copy is hard to
+   read past two lines; on a phone it is a 40-line block.
+8. "Agentic AI Foundation (AAIF) Community London" wraps to three lines as a
+   section title on a phone.
+9. Embed cards reserve fixed heights (LinkedIn 650 px) and show as large empty
+   boxes while the third party loads, or forever if it is blocked.
+10. The phone page is ~16,600 px tall. Every card is full-width and full
+    height; there is no way to skim.
+11. The nav drawer is 70 % wide with no backdrop; tapping outside does not
+    close it.
+
+Structure and semantics
+
+12. There is no `<h1>` (it is commented out in the hero). The page's only
+    name is the `<title>`.
+13. All cards weigh the same. SlideOps (the one thing the owner is shipping
+    now) gets a wider card but the same visual treatment as a 2019 GPU
+    server post.
+14. List bullets are hand-positioned with inline styles; `<b>Career:</b>`
+    sits directly inside a `<ul>` (invalid); the plot image has no `alt`;
+    the copyright year is hard-coded.
+15. There is no light theme and no `color-scheme` hint; the OS-level dark
+    scrollbar/form control colours are not requested.
+
+### Non-negotiables carried into every variant
+
+Every variant keeps: all content, links and alt text; the WebP `<picture>`
+pattern with lazy loading and intrinsic sizes; `prefers-reduced-motion`;
+`:focus-visible`; the skip link; pinch-zoom (no `user-scalable=no`);
+`theme-color`; the GA tag; WCAG AA contrast; strict HTML5. Every variant also
+adopts the cheap hygiene fixes: a real small favicon (SVG + 32/180 px PNG), a
+small header-logo asset, OG/Twitter meta, a visible or visually-hidden `<h1>`,
+`alt` on every image, an automatic copyright year, valid list markup.
+
+## The portfolio
+
+Seven variants, each on its own branch and worktree, each bundled into a
+private preview. Ordered from "would almost certainly merge" to "a real bet".
+
+### Tier 1 — safe wins (same look, better site)
+
+**v01 · Tune-up.** No visual change on desktop. Fixes findings 1–6, 11, 12,
+14, 15. Replaces Font Awesome with an inline SVG sprite of the ~30 glyphs
+actually used; self-hosts nothing new. Preloads the hero image and font CSS.
+Phone-only layout fixes: left-aligned hero copy under 600 px, tighter section
+titles, drawer backdrop and outside-tap close, single-column button stacks
+become a wrapping row. Deletes the dead template and the PNG fallbacks.
+Reports before/after transfer size and request count.
+
+**v02 · Motion & polish.** Everything in v01 plus a considered motion layer:
+staggered hero entrance, cards reveal on scroll from a visible resting state
+(never `opacity: 0` at rest), image zoom on card hover, a sliding nav
+indicator, a thin reading-progress line under the header, a back-to-top
+control, and a hero background that responds gently to pointer position.
+All gated behind `prefers-reduced-motion`.
+
+### Tier 2 — daring (new layout, same content)
+
+**v03 · Editorial.** A magazine treatment. Split hero: a large typographic
+name and one-line thesis on the left with a short "now" strip (role, AAIF,
+PhD), the portrait on the right. Sections become editorial rows: one featured
+item with a full-bleed image and a list of the rest, instead of a uniform
+grid. A sticky in-page table of contents on wide screens. A warm-paper light
+theme with a dark counterpart and a toggle; a serif display face paired with
+a humanist sans.
+
+**v04 · Bento.** The site as a dashboard, which is how an MLOps engineer
+reads the world. The hero is a bento grid: portrait tile, one-line thesis,
+figure tiles drawn from the content (200 collaborators, 20 GB/s → 200 MB/s,
+£6.1K raised, Europe's largest AI meetup), tag chips, a monospace status
+line. Sections keep bento tiles of mixed span so the important items are
+literally bigger. Cool neutrals, moss accent kept.
+
+**v05 · Timeline.** The content is a career arc, so the page becomes one:
+Your Universe festival (2010–15) → Fermilab DAQ on-call (2017–19) → PhD and
+the g−2 result → DevOps awards (2022–23) → Electric Twin → AAIF London →
+SlideOps (2026). A vertical spine carries the network-line motif from the
+current hero; chapters snap in as you scroll with sticky year markers.
+Cards become entries with a date, a one-line summary and an expandable body,
+which also fixes the phone-height problem.
+
+### Tier 3 — unique (form follows the person)
+
+**v06 · Pipeline.** The portfolio as an MLOps pipeline. The hero is an
+interactive DAG drawn on canvas — physics → data → platform → community →
+writing — whose nodes are the nav; clicking one scrolls to its stage.
+Each section is a pipeline stage with a status chip, a monospace metadata
+line (inputs, outputs, duration) and its outputs listed as artifacts. A
+command palette (⌘K / Ctrl-K) searches every section, link and article.
+The hero copy types in like a CLI session. Strict monochrome plus one accent.
+
+**v07 · Muon.** Physics as the visual language. The hero background is a
+canvas simulation of muons precessing in the g−2 storage ring (the actual
+experiment), reacting to the pointer and frozen under reduced motion. The
+page is set like a paper: an abstract, numbered sections (1 Community,
+2 Engineering, 3 Research, 4 Outreach, 5 Interests), figures with numbered
+captions, a references list that collects every external link. A scientific
+serif for display, a clean sans for body, tabular figures. A palette chosen
+for the subject rather than inherited.
+
+## How to inspect
+
+Each variant lives on a branch named
+`claude/website-design-variants-ff49ga-vNN-<slug>` and carries its own
+`VARIANT.md` describing what changed and why. `tools/preview_bundle.py`
+turns any variant's `index.html` into a single self-contained file (images
+inlined, embeds replaced by poster facades because the private preview host
+blocks third-party frames) which is what the private preview links show.
+The real branch keeps the live embeds.

--- a/tools/preview_bundle.py
+++ b/tools/preview_bundle.py
@@ -125,7 +125,7 @@ def facade(tag: str, cache: Path) -> str:
     return GENERIC_FACADE.format(href=url, h=h, bg="#1a1a1a", fg="#fff", kind="Embedded frame", title=url)
 
 
-def bundle(site: Path, cache: Path) -> str:
+def bundle(site: Path, cache: Path, title: str | None = None) -> str:
     """Produce the single-file preview HTML for the site directory."""
     src = (site / "index.html").read_text(encoding="utf-8")
 
@@ -180,6 +180,20 @@ def bundle(site: Path, cache: Path) -> str:
 
     src = re.sub(r"<picture\b[^>]*>.*?</picture>", picture_repl, src, flags=re.S)
 
+    sprites: dict[str, str] = {}
+
+    def use_repl(m: re.Match[str]) -> str:
+        target = resolve(site, html.unescape(m.group(1)))
+        if not target or target.suffix.lower() != ".svg":
+            return m.group(0)
+        sprites.setdefault(str(target), target.read_text(encoding="utf-8"))
+        return f'href="#{m.group(2)}"'
+
+    src = re.sub(r'(?:xlink:)?href="([^"#]+\.svg)#([^"]+)"', use_repl, src)
+    if sprites:
+        hidden = "".join(re.sub(r"<svg\b", '<svg style="display:none" aria-hidden="true"', t, count=1) for t in sprites.values())
+        src = re.sub(r"(<body\b[^>]*>)", lambda m: m.group(1) + hidden, src, count=1)
+
     def attr_repl(m: re.Match[str]) -> str:
         target = resolve(site, html.unescape(m.group(2)))
         return f'{m.group(1)}="{data_uri(target) if target else m.group(2)}"'
@@ -201,6 +215,8 @@ def bundle(site: Path, cache: Path) -> str:
     src = re.sub(r"<iframe\b[^>]*>\s*</iframe>", lambda m: facade(m.group(0), cache), src, flags=re.S)
     src = re.sub(r'href="((?:\./)?files/[^"]+)"', lambda m: f'href="https://glukicov.github.io/{m.group(1).lstrip("./")}"', src)
     src = re.sub(r"^\s*<!doctype html>\s*", "", src, flags=re.I)
+    if title:
+        src = re.sub(r"<title>.*?</title>", f"<title>{html.escape(title)}</title>", src, count=1, flags=re.S)
     return src
 
 
@@ -210,8 +226,9 @@ def main() -> None:
     ap.add_argument("site", type=Path)
     ap.add_argument("out", type=Path)
     ap.add_argument("--cache", type=Path, default=Path.home() / ".cache" / "preview-bundle")
+    ap.add_argument("--title", help="Replace the page <title> in the preview")
     a = ap.parse_args()
-    out = bundle(a.site, a.cache)
+    out = bundle(a.site, a.cache, a.title)
     a.out.write_text(out, encoding="utf-8")
     print(f"{a.out}: {len(out.encode()) / 1024:.0f} KB")
 

--- a/tools/preview_bundle.py
+++ b/tools/preview_bundle.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 """Bundle a variant's index.html into one self-contained preview file.
 
+The doctype is kept: without it the page renders in quirks mode, where a
+percentage height on an auto-height parent resolves against the viewport and
+silently clips tall cards that are fine on the real site.
+
 The private preview host only admits the page's own bytes, Google Fonts and a
 few script CDNs, so this script inlines every local image, stylesheet and
 script as data URIs or inline blocks, inlines Font Awesome (CSS plus woff2)
@@ -214,7 +218,6 @@ def bundle(site: Path, cache: Path, title: str | None = None) -> str:
     src = re.sub(r'srcset="([^"]+)"', srcset_repl, src)
     src = re.sub(r"<iframe\b[^>]*>\s*</iframe>", lambda m: facade(m.group(0), cache), src, flags=re.S)
     src = re.sub(r'href="((?:\./)?files/[^"]+)"', lambda m: f'href="https://glukicov.github.io/{m.group(1).lstrip("./")}"', src)
-    src = re.sub(r"^\s*<!doctype html>\s*", "", src, flags=re.I)
     if title:
         src = re.sub(r"<title>.*?</title>", f"<title>{html.escape(title)}</title>", src, count=1, flags=re.S)
     return src

--- a/tools/preview_bundle.py
+++ b/tools/preview_bundle.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Bundle a variant's index.html into one self-contained preview file.
+
+The private preview host only admits the page's own bytes, Google Fonts and a
+few script CDNs, so this script inlines every local image, stylesheet and
+script as data URIs or inline blocks, inlines Font Awesome (CSS plus woff2)
+when the page links it from cdnjs, strips the analytics tag, and replaces each
+third-party iframe with a static poster facade that links out to the original.
+Nothing here changes the real site; the branch keeps the live embeds.
+
+Usage: preview_bundle.py <site-dir> <out.html> [--cache <dir>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import html
+import mimetypes
+import re
+import urllib.request
+from pathlib import Path
+
+MIME = {
+    ".webp": "image/webp",
+    ".svg": "image/svg+xml",
+    ".woff2": "font/woff2",
+    ".ico": "image/x-icon",
+    ".avif": "image/avif",
+}
+
+
+def data_uri(path: Path) -> str:
+    """Return a base64 data URI for a local file, guessing the MIME type."""
+    mime = MIME.get(path.suffix.lower()) or mimetypes.guess_type(str(path))[0] or "application/octet-stream"
+    return f"data:{mime};base64,{base64.b64encode(path.read_bytes()).decode()}"
+
+
+def fetch(url: str, cache: Path) -> bytes:
+    """Download a URL once and cache it on disk by URL hash."""
+    cache.mkdir(parents=True, exist_ok=True)
+    key = cache / hashlib.sha1(url.encode()).hexdigest()
+    if not key.exists():
+        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0 preview-bundle"})
+        key.write_bytes(urllib.request.urlopen(req, timeout=60).read())
+    return key.read_bytes()
+
+
+def resolve(site: Path, ref: str) -> Path | None:
+    """Map a relative URL in the page to a file under the site directory, or None."""
+    ref = ref.split("?")[0].split("#")[0].strip()
+    if not ref or ref.startswith(("http:", "https:", "data:", "//", "mailto:")):
+        return None
+    candidate = (site / ref.lstrip("./")).resolve()
+    if candidate.is_file() and site.resolve() in candidate.parents:
+        if candidate.suffix.lower() == ".gif" and candidate.with_suffix(".webp").exists():
+            candidate = candidate.with_suffix(".webp")
+        return candidate
+    return None
+
+
+def inline_css_urls(css: str, base: Path, site: Path) -> str:
+    """Replace url(...) references to local files inside a CSS block."""
+
+    def repl(m: re.Match[str]) -> str:
+        ref = m.group(2)
+        target = resolve(base, ref) or resolve(site, ref)
+        return f"url({m.group(1)}{data_uri(target) if target else ref}{m.group(1)})"
+
+    return re.sub(r"url\((['\"]?)([^'\")]+)\1\)", repl, css)
+
+
+def inline_font_awesome(css_text: str, cache: Path) -> str:
+    """Rewrite Font Awesome's font URLs to inlined woff2 data URIs (drop the ttf sources)."""
+    base = "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/webfonts/"
+
+    def src(m: re.Match[str]) -> str:
+        name = m.group(1)
+        uri = "data:font/woff2;base64," + base64.b64encode(fetch(base + name, cache)).decode()
+        return f'src:url("{uri}") format("woff2")'
+
+    css_text = re.sub(r"src:url\(\.\./webfonts/([^)]+\.woff2)\) format\(\"woff2\"\),url\([^)]+\) format\(\"truetype\"\)", src, css_text)
+    return css_text
+
+
+YT_POSTER = (
+    '<a class="pv-facade" href="https://www.youtube.com/watch?v={vid}" target="_blank" rel="noopener" '
+    'style="display:block;position:relative;width:100%;aspect-ratio:16/9;background:#000 url({poster}) center/cover;overflow:hidden">'
+    '<span style="position:absolute;inset:0;display:grid;place-items:center">'
+    '<span style="width:68px;height:48px;border-radius:12px;background:rgba(0,0,0,.72);display:grid;place-items:center">'
+    '<svg viewBox="0 0 24 24" width="28" height="28" aria-hidden="true"><path d="M8 5v14l11-7z" fill="#fff"/></svg></span></span>'
+    '<span style="position:absolute;left:0;right:0;bottom:0;padding:.35rem .6rem;font:600 .7rem/1.3 system-ui,sans-serif;'
+    'letter-spacing:.04em;text-transform:uppercase;color:#ddd;background:linear-gradient(transparent,rgba(0,0,0,.75))">'
+    'Preview poster · live embed on the real site</span></a>'
+)
+
+GENERIC_FACADE = (
+    '<a class="pv-facade" href="{href}" target="_blank" rel="noopener" '
+    'style="display:flex;flex-direction:column;justify-content:center;gap:.5rem;width:100%;min-height:{h}px;padding:1.5rem;'
+    'box-sizing:border-box;background:{bg};color:{fg};text-decoration:none;font-family:system-ui,sans-serif">'
+    '<span style="font-size:.7rem;letter-spacing:.08em;text-transform:uppercase;opacity:.7">{kind}</span>'
+    '<span style="font-size:1.1rem;font-weight:600;line-height:1.3">{title}</span>'
+    '<span style="font-size:.8rem;opacity:.7">Preview placeholder · the real site embeds this live. Click to open.</span></a>'
+)
+
+
+def facade(tag: str, cache: Path) -> str:
+    """Turn one <iframe ...></iframe> into a static, clickable facade."""
+    src = re.search(r'src="([^"]+)"', tag)
+    if not src:
+        return ""
+    url = html.unescape(src.group(1))
+    yt = re.search(r"youtube(?:-nocookie)?\.com/embed/([A-Za-z0-9_-]{6,})", url)
+    if yt:
+        vid = yt.group(1)
+        poster = "data:image/jpeg;base64," + base64.b64encode(fetch(f"https://i.ytimg.com/vi/{vid}/hqdefault.jpg", cache)).decode()
+        return YT_POSTER.format(vid=vid, poster=poster)
+    height = re.search(r'height="(\d+)"', tag)
+    h = height.group(1) if height else "320"
+    if "spotify.com" in url:
+        return GENERIC_FACADE.format(href=url.replace("/embed/", "/"), h=h, bg="#1a1a1a", fg="#fff", kind="Spotify episode", title="Electric Twin & MLOps Community London")
+    if "linkedin.com" in url:
+        return GENERIC_FACADE.format(href="https://www.linkedin.com/in/glukicov", h=h, bg="#0f1a26", fg="#e8eef4", kind="LinkedIn post", title="AAIF Community London · embedded post")
+    return GENERIC_FACADE.format(href=url, h=h, bg="#1a1a1a", fg="#fff", kind="Embedded frame", title=url)
+
+
+def bundle(site: Path, cache: Path) -> str:
+    """Produce the single-file preview HTML for the site directory."""
+    src = (site / "index.html").read_text(encoding="utf-8")
+
+    src = re.sub(r"<script[^>]*googletagmanager[^>]*></script>\s*<script>.*?gtag\(\"config\"[^<]*</script>", "", src, flags=re.S)
+
+    def link_repl(m: re.Match[str]) -> str:
+        tag = m.group(0)
+        href = re.search(r'href="([^"]+)"', tag)
+        if not href:
+            return tag
+        ref = html.unescape(href.group(1))
+        if "font-awesome" in ref and "cdnjs.cloudflare.com" in ref:
+            css_text = fetch(ref, cache).decode()
+            return f"<style>{inline_font_awesome(css_text, cache)}</style>"
+        if 'rel="stylesheet"' in tag or "stylesheet" in tag:
+            target = resolve(site, ref)
+            if target:
+                return f"<style>{inline_css_urls(target.read_text(encoding='utf-8'), target.parent, site)}</style>"
+        if "icon" in tag or "preload" in tag:
+            target = resolve(site, ref)
+            if target:
+                return tag.replace(href.group(1), data_uri(target))
+        return tag
+
+    src = re.sub(r"<link\b[^>]*>", link_repl, src)
+
+    def script_repl(m: re.Match[str]) -> str:
+        tag = m.group(0)
+        s = re.search(r'src="([^"]+)"', tag)
+        target = resolve(site, html.unescape(s.group(1))) if s else None
+        if target:
+            attrs = re.sub(r'\ssrc="[^"]+"', "", tag[: tag.index(">") + 1])
+            return f"{attrs}{target.read_text(encoding='utf-8')}</script>"
+        return tag
+
+    src = re.sub(r"<script\b[^>]*\bsrc=\"[^\"]+\"[^>]*>\s*</script>", script_repl, src)
+    src = re.sub(r"<style\b[^>]*>(.*?)</style>", lambda m: m.group(0).replace(m.group(1), inline_css_urls(m.group(1), site, site)), src, flags=re.S)
+    src = re.sub(r'style="([^"]*url\([^"]*)"', lambda m: 'style="' + inline_css_urls(m.group(1), site, site) + '"', src)
+
+    def picture_repl(m: re.Match[str]) -> str:
+        block = m.group(0)
+        webp = re.search(r'<source[^>]*srcset="([^"]+\.webp)"[^>]*>', block)
+        img = re.search(r"<img\b[^>]*>", block)
+        if webp and img:
+            target = resolve(site, webp.group(1))
+            if target:
+                new_img = re.sub(r'src="[^"]+"', f'src="{data_uri(target)}"', img.group(0))
+                return new_img
+        return block
+
+    src = re.sub(r"<picture\b[^>]*>.*?</picture>", picture_repl, src, flags=re.S)
+
+    def attr_repl(m: re.Match[str]) -> str:
+        target = resolve(site, html.unescape(m.group(2)))
+        return f'{m.group(1)}="{data_uri(target) if target else m.group(2)}"'
+
+    src = re.sub(r'\b(src|poster|href)="((?:\./)?(?:images|assets|img|media)/[^"]+)"', attr_repl, src)
+
+    def srcset_repl(m: re.Match[str]) -> str:
+        parts = []
+        for item in m.group(1).split(","):
+            bits = item.strip().split()
+            if not bits:
+                continue
+            target = resolve(site, bits[0])
+            bits[0] = data_uri(target) if target else bits[0]
+            parts.append(" ".join(bits))
+        return f'srcset="{", ".join(parts)}"'
+
+    src = re.sub(r'srcset="([^"]+)"', srcset_repl, src)
+    src = re.sub(r"<iframe\b[^>]*>\s*</iframe>", lambda m: facade(m.group(0), cache), src, flags=re.S)
+    src = re.sub(r'href="((?:\./)?files/[^"]+)"', lambda m: f'href="https://glukicov.github.io/{m.group(1).lstrip("./")}"', src)
+    src = re.sub(r"^\s*<!doctype html>\s*", "", src, flags=re.I)
+    return src
+
+
+def main() -> None:
+    """CLI entry point."""
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("site", type=Path)
+    ap.add_argument("out", type=Path)
+    ap.add_argument("--cache", type=Path, default=Path.home() / ".cache" / "preview-bundle")
+    a = ap.parse_args()
+    out = bundle(a.site, a.cache)
+    a.out.write_text(out, encoding="utf-8")
+    print(f"{a.out}: {len(out.encode()) / 1024:.0f} KB")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/preview_bundle.py
+++ b/tools/preview_bundle.py
@@ -129,6 +129,8 @@ def bundle(site: Path, cache: Path) -> str:
     """Produce the single-file preview HTML for the site directory."""
     src = (site / "index.html").read_text(encoding="utf-8")
 
+    src = re.sub(r"<!--.*?-->", "", src, flags=re.S)
+    src = re.sub(r"<style\b[^>]*>(.*?)</style>", lambda m: m.group(0).replace(m.group(1), re.sub(r"/\*.*?\*/", "", m.group(1), flags=re.S)), src, flags=re.S)
     src = re.sub(r"<script[^>]*googletagmanager[^>]*></script>\s*<script>.*?gtag\(\"config\"[^<]*</script>", "", src, flags=re.S)
 
     def link_repl(m: re.Match[str]) -> str:


### PR DESCRIPTION
This branch is the index for a design exploration. It adds no site changes of its own: a written review of the current site, the plan for seven variants, and the tool that turns any variant into a single self-contained preview page.

Each variant lives on its own branch with its own pull request, so they can be read and merged independently. Nothing here changes the live site.

## What is in this branch

- `DESIGN-VARIANTS.md` — the review of the current site (15 findings), the brief for each variant, the results table with preview links, and the findings that apply whichever variant wins.
- `tools/preview_bundle.py` — stdlib-only bundler that inlines every local image, stylesheet and script as data URIs, inlines Font Awesome where a variant still uses it, and replaces the six third-party embeds with poster facades that link out. The preview host admits only a page's own bytes, so previews need this; the variant branches keep the real live embeds.

## The seven variants

Ordered from most conservative to most adventurous. Every one keeps all content, links, alt text and the six live embeds, and adopts the same hygiene fixes: a small favicon and logo replacing the 489 KB `icon.png`, Open Graph and Twitter card meta, a real `h1`, alt on every image, an automatic copyright year and valid list markup.

| Variant | Idea |
|---|---|
| v01 Tune-up | Identical pixels on desktop. Performance, semantics, phone fixes, 11.3 MB of dead assets removed. |
| v02 Motion | Today's look plus eleven motion pieces, each animating from an already-readable state. |
| v03 Editorial | A magazine treatment on paper stock with a masthead name, featured stories and a light/dark toggle. |
| v04 Bento | A 12-column dashboard where every number already on the page becomes a figure tile. |
| v05 Timeline | The career as one vertical timeline with expandable dated entries. |
| v06 Pipeline | The portfolio as an MLOps run: an interactive DAG for navigation and a command palette. |
| v07 Muon | The page set like a physics paper over a canvas simulation of the g−2 storage ring. |

## Findings that apply whichever variant wins

- The 489 KB `images/icon.png` serving a 40 px logo is the single biggest easy win.
- The sticky header's `backdrop-filter` makes the header the containing block for its own fixed-position descendants, so the mobile drawer opens clipped to the header strip. Three variants hit this independently and fixed it by moving the frosted layer to a `::before`. Worth checking on the live site.
- No display face has been seen for real. The build environment cannot reach `fonts.googleapis.com`, so every screenshot fell back to system fonts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vv3Nbr7BnLeHbvwTaUL4Xs